### PR TITLE
Feature/claude chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, feature/*]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Nuxt app
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuxt-build
+          path: .output/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      preview:
+        description: 'Start preview server with public URL?'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      preview_minutes:
+        description: 'Preview timeout (minutes)'
+        required: false
+        default: '30'
       push_docker:
         description: 'Push Docker image after build?'
         required: true
@@ -46,6 +58,35 @@ jobs:
           name: nuxt-build
           path: .output/
           retention-days: 7
+
+      # Preview server - only run if manually triggered with preview=true
+      - name: Start preview server with public URL
+        if: ${{ inputs.preview == 'true' }}
+        timeout-minutes: ${{ fromJSON(inputs.preview_minutes || '30') }}
+        run: |
+          echo "## 🚀 Starting Preview Server" >> $GITHUB_STEP_SUMMARY
+
+          # Install cloudflared
+          curl -sL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
+          chmod +x cloudflared
+
+          # Start Nuxt server in background
+          node .output/server/index.mjs &
+          sleep 3
+
+          # Verify server is running
+          curl -sf http://localhost:3000 > /dev/null && echo "✅ Server started successfully"
+
+          echo ""
+          echo "=========================================="
+          echo "🌐 Creating public tunnel..."
+          echo "   Look for the URL below (https://xxxx.trycloudflare.com)"
+          echo "   Server will run for ${{ inputs.preview_minutes || '30' }} minutes or until cancelled"
+          echo "=========================================="
+          echo ""
+
+          # Create tunnel - this will print the public URL and block
+          ./cloudflared tunnel --url http://localhost:3000
 
       # Docker steps - only run if manually triggered with push_docker=true
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,20 @@ on:
     branches: [main, feature/*]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      push_docker:
+        description: 'Push Docker image after build?'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      docker_tag:
+        description: 'Docker image tag (if pushing)'
+        required: false
+        default: 'latest'
 
 jobs:
   build:
@@ -32,3 +46,31 @@ jobs:
           name: nuxt-build
           path: .output/
           retention-days: 7
+
+      # Docker steps - only run if manually triggered with push_docker=true
+      - name: Set up Docker Buildx
+        if: ${{ inputs.push_docker == 'true' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.push_docker == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: ${{ inputs.push_docker == 'true' }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: droneblocks/dexi-droneblocks:${{ inputs.docker_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        if: ${{ inputs.push_docker == 'true' }}
+        run: |
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** droneblocks/dexi-droneblocks:${{ inputs.docker_tag }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,34 @@
+name: Claude Assistant
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-response:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Trigger on @claude mentions, 'claude' label, or 'claude' assignee
+          trigger_phrase: "@claude"
+          label_trigger: "claude"
+          assignee_trigger: "claude"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., 0.14, latest, claude-chat)'
+        required: true
+        default: 'latest'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            droneblocks/dexi-droneblocks:${{ inputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** droneblocks/dexi-droneblocks:${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,31 @@
-FROM nginx:latest
-RUN apt update && rm -rf /usr/share/nginx/html/*
-ADD .output/public /usr/share/nginx/html
+# Build stage
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+# Copy built output
+COPY --from=builder /app/.output ./.output
+COPY --from=builder /app/package.json ./
+
+# Set environment
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+EXPOSE 3000
+
+# Run the server
+CMD ["node", ".output/server/index.mjs"]

--- a/assets/ts/demos.ts
+++ b/assets/ts/demos.ts
@@ -1,0 +1,798 @@
+export interface Demo {
+  id: string;
+  name: string;
+  description: string;
+  category: 'basic' | 'navigation' | 'led' | 'apriltag' | 'advanced';
+  blocklyXml: string;
+}
+
+export const demos: Demo[] = [
+  {
+    id: 'led-pixel-loop',
+    name: 'LED Pixel Loop',
+    description: 'Reset LEDs to black, then loop through all 45 pixels lighting each one white.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <variables>
+    <variable id="i_var">i</variable>
+  </variables>
+  <block type="led_ring" x="50" y="50">
+    <field name="color">black</field>
+    <next>
+      <block type="controls_for">
+    <field name="VAR" id="i_var">i</field>
+    <value name="FROM">
+      <shadow type="math_number"><field name="NUM">0</field></shadow>
+    </value>
+    <value name="TO">
+      <shadow type="math_number"><field name="NUM">44</field></shadow>
+    </value>
+    <value name="BY">
+      <shadow type="math_number"><field name="NUM">1</field></shadow>
+    </value>
+    <statement name="DO">
+      <block type="led_pixel">
+        <value name="index">
+          <block type="variables_get">
+            <field name="VAR" id="i_var">i</field>
+          </block>
+        </value>
+        <value name="red">
+          <shadow type="math_number"><field name="NUM">255</field></shadow>
+        </value>
+        <value name="green">
+          <shadow type="math_number"><field name="NUM">255</field></shadow>
+        </value>
+        <value name="blue">
+          <shadow type="math_number"><field name="NUM">255</field></shadow>
+        </value>
+        <next>
+          <block type="nav_wait">
+            <value name="DURATION">
+              <shadow type="math_number"><field name="NUM">0.1</field></shadow>
+            </value>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'led-light-show',
+    name: 'LED Light Show',
+    description: 'Cycle through different LED effects: rainbow, police, and solid colors.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="led_effect" x="50" y="50">
+    <field name="EFFECT">rainbow</field>
+    <next>
+      <block type="nav_wait">
+        <value name="DURATION">
+          <shadow type="math_number"><field name="NUM">3</field></shadow>
+        </value>
+        <next>
+          <block type="led_effect">
+            <field name="EFFECT">police</field>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">3</field></shadow>
+                </value>
+                <next>
+                  <block type="led_ring">
+                    <field name="color">green</field>
+                    <next>
+                      <block type="nav_wait">
+                        <value name="DURATION">
+                          <shadow type="math_number"><field name="NUM">3</field></shadow>
+                        </value>
+                        <next>
+                          <block type="led_effect">
+                            <field name="EFFECT">off</field>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'takeoff-land',
+    name: 'Takeoff and Land',
+    description: 'Basic sequence: arm, switch to offboard mode, takeoff to 3m, wait 3 seconds, land, and disarm.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">3</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">3</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_land">
+                    <next>
+                      <block type="nav_disarm"></block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'color-cycle',
+    name: 'Color Cycle',
+    description: 'Cycle the LED ring through red, green, and blue colors.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="led_ring" x="50" y="50">
+    <field name="color">red</field>
+    <next>
+      <block type="nav_wait">
+        <value name="DURATION">
+          <shadow type="math_number"><field name="NUM">2</field></shadow>
+        </value>
+        <next>
+          <block type="led_ring">
+            <field name="color">green</field>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="led_ring">
+                    <field name="color">blue</field>
+                    <next>
+                      <block type="nav_wait">
+                        <value name="DURATION">
+                          <shadow type="math_number"><field name="NUM">2</field></shadow>
+                        </value>
+                        <next>
+                          <block type="led_ring">
+                            <field name="color">black</field>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'hover-in-place',
+    name: 'Hover in Place',
+    description: 'Takeoff and hover in place for 10 seconds before landing.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">10</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_land">
+                    <next>
+                      <block type="nav_disarm"></block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'up-and-down',
+    name: 'Up and Down',
+    description: 'Vertical flight demo: takeoff, fly up 2m, fly down 2m, land.',
+    category: 'basic',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_up">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_wait">
+                        <value name="DURATION">
+                          <shadow type="math_number"><field name="NUM">2</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_down">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">2</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_wait">
+                                <value name="DURATION">
+                                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                                </value>
+                                <next>
+                                  <block type="nav_land">
+                                    <next>
+                                      <block type="nav_disarm"></block>
+                                    </next>
+                                  </block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'square-pattern',
+    name: 'Square Pattern',
+    description: 'Fly in a 2m x 2m square pattern at 3m altitude.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">3</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_forward">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_fly_right">
+                        <value name="DISTANCE">
+                          <shadow type="math_number"><field name="NUM">2</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_backward">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">2</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_fly_left">
+                                <value name="DISTANCE">
+                                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                                </value>
+                                <next>
+                                  <block type="nav_land">
+                                    <next>
+                                      <block type="nav_disarm"></block>
+                                    </next>
+                                  </block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'yaw-spin',
+    name: 'Yaw Spin',
+    description: 'Takeoff and perform a 360° rotation using yaw commands.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">3</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_yaw_left">
+                    <value name="DEGREES">
+                      <shadow type="math_number"><field name="NUM">90</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_yaw_left">
+                        <value name="DEGREES">
+                          <shadow type="math_number"><field name="NUM">90</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_yaw_left">
+                            <value name="DEGREES">
+                              <shadow type="math_number"><field name="NUM">90</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_yaw_left">
+                                <value name="DEGREES">
+                                  <shadow type="math_number"><field name="NUM">90</field></shadow>
+                                </value>
+                                <next>
+                                  <block type="nav_wait">
+                                    <value name="DURATION">
+                                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                                    </value>
+                                    <next>
+                                      <block type="nav_land">
+                                        <next>
+                                          <block type="nav_disarm"></block>
+                                        </next>
+                                      </block>
+                                    </next>
+                                  </block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'forward-backward',
+    name: 'Forward and Back',
+    description: 'Fly forward 2m, wait, then fly backward 2m.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_forward">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_wait">
+                        <value name="DURATION">
+                          <shadow type="math_number"><field name="NUM">2</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_backward">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">2</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_land">
+                                <next>
+                                  <block type="nav_disarm"></block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'left-right',
+    name: 'Left and Right',
+    description: 'Fly left 2m, wait, then fly right 2m.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_left">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_wait">
+                        <value name="DURATION">
+                          <shadow type="math_number"><field name="NUM">2</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_right">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">2</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_land">
+                                <next>
+                                  <block type="nav_disarm"></block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'triangle-pattern',
+    name: 'Triangle Pattern',
+    description: 'Fly in a triangular pattern using forward and yaw movements.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_forward">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_yaw_right">
+                        <value name="DEGREES">
+                          <shadow type="math_number"><field name="NUM">120</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_forward">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">2</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_yaw_right">
+                                <value name="DEGREES">
+                                  <shadow type="math_number"><field name="NUM">120</field></shadow>
+                                </value>
+                                <next>
+                                  <block type="nav_fly_forward">
+                                    <value name="DISTANCE">
+                                      <shadow type="math_number"><field name="NUM">2</field></shadow>
+                                    </value>
+                                    <next>
+                                      <block type="nav_yaw_right">
+                                        <value name="DEGREES">
+                                          <shadow type="math_number"><field name="NUM">120</field></shadow>
+                                        </value>
+                                        <next>
+                                          <block type="nav_land">
+                                            <next>
+                                              <block type="nav_disarm"></block>
+                                            </next>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </next>
+                                  </block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'zigzag-pattern',
+    name: 'Zigzag Pattern',
+    description: 'Fly in a zigzag pattern: forward-right, forward-left, repeat.',
+    category: 'navigation',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="nav_wait">
+                <value name="DURATION">
+                  <shadow type="math_number"><field name="NUM">2</field></shadow>
+                </value>
+                <next>
+                  <block type="nav_fly_forward">
+                    <value name="DISTANCE">
+                      <shadow type="math_number"><field name="NUM">1</field></shadow>
+                    </value>
+                    <next>
+                      <block type="nav_fly_right">
+                        <value name="DISTANCE">
+                          <shadow type="math_number"><field name="NUM">1</field></shadow>
+                        </value>
+                        <next>
+                          <block type="nav_fly_forward">
+                            <value name="DISTANCE">
+                              <shadow type="math_number"><field name="NUM">1</field></shadow>
+                            </value>
+                            <next>
+                              <block type="nav_fly_left">
+                                <value name="DISTANCE">
+                                  <shadow type="math_number"><field name="NUM">1</field></shadow>
+                                </value>
+                                <next>
+                                  <block type="nav_fly_forward">
+                                    <value name="DISTANCE">
+                                      <shadow type="math_number"><field name="NUM">1</field></shadow>
+                                    </value>
+                                    <next>
+                                      <block type="nav_fly_right">
+                                        <value name="DISTANCE">
+                                          <shadow type="math_number"><field name="NUM">1</field></shadow>
+                                        </value>
+                                        <next>
+                                          <block type="nav_land">
+                                            <next>
+                                              <block type="nav_disarm"></block>
+                                            </next>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </next>
+                                  </block>
+                                </next>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'apriltag-led',
+    name: 'Tag Triggers LED',
+    description: 'Start monitoring AprilTags, when a tag is detected turn on rainbow LED effect.',
+    category: 'apriltag',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="apriltag_start_monitoring" x="50" y="50">
+    <next>
+      <block type="nav_wait">
+        <value name="DURATION">
+          <shadow type="math_number"><field name="NUM">5</field></shadow>
+        </value>
+        <next>
+          <block type="controls_if">
+            <value name="IF0">
+              <block type="logic_compare">
+                <field name="OP">GTE</field>
+                <value name="A">
+                  <block type="apriltag_get_last_id"></block>
+                </value>
+                <value name="B">
+                  <block type="math_number">
+                    <field name="NUM">0</field>
+                  </block>
+                </value>
+              </block>
+            </value>
+            <statement name="DO0">
+              <block type="led_effect">
+                <field name="EFFECT">rainbow</field>
+              </block>
+            </statement>
+            <next>
+              <block type="apriltag_stop_monitoring"></block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  },
+  {
+    id: 'apriltag-land',
+    name: 'Tag 1 Triggers Land',
+    description: 'While flying, if AprilTag ID 1 is detected, land the drone.',
+    category: 'apriltag',
+    blocklyXml: `<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="nav_arm" x="50" y="50">
+    <next>
+      <block type="nav_switch_offboard_mode">
+        <next>
+          <block type="nav_takeoff">
+            <value name="ALTITUDE">
+              <shadow type="math_number"><field name="NUM">2</field></shadow>
+            </value>
+            <next>
+              <block type="apriltag_start_monitoring">
+                <next>
+                  <block type="nav_wait">
+                    <value name="DURATION">
+                      <shadow type="math_number"><field name="NUM">5</field></shadow>
+                    </value>
+                    <next>
+                      <block type="controls_if">
+                        <value name="IF0">
+                          <block type="logic_compare">
+                            <field name="OP">EQ</field>
+                            <value name="A">
+                              <block type="apriltag_get_last_id"></block>
+                            </value>
+                            <value name="B">
+                              <block type="math_number">
+                                <field name="NUM">1</field>
+                              </block>
+                            </value>
+                          </block>
+                        </value>
+                        <statement name="DO0">
+                          <block type="nav_land">
+                            <next>
+                              <block type="nav_disarm"></block>
+                            </next>
+                          </block>
+                        </statement>
+                        <next>
+                          <block type="apriltag_stop_monitoring"></block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </next>
+  </block>
+</xml>`
+  }
+];
+
+export function getDemoById(id: string): Demo | undefined {
+  return demos.find(demo => demo.id === id);
+}
+
+export function getDemosByCategory(category: Demo['category']): Demo[] {
+  return demos.filter(demo => demo.category === category);
+}

--- a/components/ClaudeChat.vue
+++ b/components/ClaudeChat.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { ref, nextTick, watch } from "vue";
+import { useClaudeChat, type DroneContext } from "~/composables/useClaudeChat";
+
+const props = defineProps<{
+  droneContext?: DroneContext;
+}>();
+
+const { messages, isLoading, error, hasMessages, sendMessage, clearMessages } =
+  useClaudeChat();
+
+const inputMessage = ref("");
+const chatContainer = ref<HTMLElement | null>(null);
+
+const scrollToBottom = () => {
+  nextTick(() => {
+    if (chatContainer.value) {
+      chatContainer.value.scrollTop = chatContainer.value.scrollHeight;
+    }
+  });
+};
+
+watch(messages, scrollToBottom, { deep: true });
+
+const handleSend = async () => {
+  const message = inputMessage.value.trim();
+  if (!message || isLoading.value) return;
+
+  inputMessage.value = "";
+  await sendMessage(message, props.droneContext);
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    handleSend();
+  }
+};
+
+const formatTime = (date: Date) => {
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+};
+</script>
+
+<template>
+  <div class="flex flex-col h-full bg-base-200 rounded-lg overflow-hidden">
+    <!-- Header -->
+    <div
+      class="flex items-center justify-between px-4 py-3 bg-base-300 border-b border-base-content/10"
+    >
+      <div class="flex items-center gap-2">
+        <span class="text-2xl">🚁</span>
+        <span class="font-semibold text-base-content">DEXI Chat</span>
+      </div>
+      <button
+        v-if="hasMessages"
+        @click="clearMessages"
+        class="btn btn-ghost btn-sm text-base-content/60 hover:text-base-content"
+      >
+        Clear
+      </button>
+    </div>
+
+    <!-- Messages -->
+    <div ref="chatContainer" class="flex-1 overflow-y-auto p-4 space-y-4">
+      <!-- Empty state -->
+      <div
+        v-if="!hasMessages"
+        class="flex flex-col items-center justify-center h-full text-base-content/50"
+      >
+        <span class="text-4xl mb-4">💬</span>
+        <p class="text-center">
+          Ask me anything about your drone!
+          <br />
+          <span class="text-sm"
+            >Try: "Set LED to blue" or "How do I takeoff?"</span
+          >
+        </p>
+      </div>
+
+      <!-- Message list -->
+      <div v-for="msg in messages" :key="msg.id" class="flex flex-col">
+        <!-- Tool results badge for assistant messages -->
+        <div
+          v-if="msg.role === 'assistant' && msg.toolResults?.length"
+          class="self-start mb-1"
+        >
+          <details class="collapse collapse-arrow bg-success/10 rounded-lg">
+            <summary class="collapse-title text-xs text-success py-1 min-h-0 px-3">
+              {{ msg.toolResults.length }} tool{{ msg.toolResults.length > 1 ? 's' : '' }} executed
+            </summary>
+            <div class="collapse-content text-xs font-mono text-base-content/70 pt-0">
+              <div v-for="(result, idx) in msg.toolResults" :key="idx" class="mb-1 whitespace-pre-wrap">
+                {{ result }}
+              </div>
+            </div>
+          </details>
+        </div>
+        <div
+          :class="[
+            'max-w-[85%] rounded-2xl px-4 py-2',
+            msg.role === 'user'
+              ? 'self-end bg-primary text-primary-content'
+              : 'self-start bg-base-300 text-base-content',
+          ]"
+        >
+          <p class="whitespace-pre-wrap">{{ msg.content }}</p>
+        </div>
+        <span
+          :class="[
+            'text-xs text-base-content/40 mt-1',
+            msg.role === 'user' ? 'self-end' : 'self-start',
+          ]"
+        >
+          {{ formatTime(msg.timestamp) }}
+        </span>
+      </div>
+
+      <!-- Loading indicator -->
+      <div v-if="isLoading" class="flex items-center gap-2 text-base-content/60">
+        <span class="loading loading-dots loading-sm"></span>
+        <span>DEXI is working...</span>
+      </div>
+
+      <!-- Error message -->
+      <div v-if="error" class="alert alert-error">
+        <span>{{ error }}</span>
+      </div>
+    </div>
+
+    <!-- Input -->
+    <div class="p-4 bg-base-300 border-t border-base-content/10">
+      <div class="flex gap-2">
+        <input
+          v-model="inputMessage"
+          @keydown="handleKeydown"
+          type="text"
+          placeholder="Talk to your drone..."
+          class="input input-bordered flex-1 bg-base-100"
+          :disabled="isLoading"
+        />
+        <button
+          @click="handleSend"
+          class="btn btn-primary"
+          :disabled="!inputMessage.trim() || isLoading"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              d="M3.478 2.404a.75.75 0 0 0-.926.941l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.404Z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/composables/useClaudeChat.ts
+++ b/composables/useClaudeChat.ts
@@ -1,0 +1,85 @@
+import { ref, computed } from "vue";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  toolResults?: string[];
+}
+
+export interface DroneContext {
+  armed?: boolean;
+  altitude?: number;
+  battery?: number;
+  mode?: string;
+}
+
+const messages = ref<ChatMessage[]>([]);
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+
+export function useClaudeChat() {
+  const hasMessages = computed(() => messages.value.length > 0);
+
+  const addMessage = (role: "user" | "assistant", content: string, toolResults?: string[]) => {
+    messages.value.push({
+      id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      role,
+      content,
+      timestamp: new Date(),
+      toolResults,
+    });
+  };
+
+  const sendMessage = async (
+    userMessage: string,
+    context?: DroneContext
+  ): Promise<void> => {
+    if (!userMessage.trim()) return;
+
+    error.value = null;
+    addMessage("user", userMessage);
+    isLoading.value = true;
+
+    try {
+      // Build message history for API (last 20 messages for context)
+      const history = messages.value.slice(-20).map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      const response = await $fetch<{ message: string; toolResults?: string[] }>("/api/chat", {
+        method: "POST",
+        body: {
+          messages: history,
+          context,
+        },
+      });
+
+      if (response.message) {
+        addMessage("assistant", response.message, response.toolResults);
+      }
+    } catch (err: unknown) {
+      const e = err as Error & { data?: { message?: string } };
+      error.value = e.data?.message || e.message || "Failed to send message";
+      console.error("Chat error:", e);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const clearMessages = () => {
+    messages.value = [];
+    error.value = null;
+  };
+
+  return {
+    messages: computed(() => messages.value),
+    isLoading: computed(() => isLoading.value),
+    error: computed(() => error.value),
+    hasMessages,
+    sendMessage,
+    clearMessages,
+  };
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,10 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   css: ['~/assets/css/main.css'],
+  runtimeConfig: {
+    // Server-side only (not exposed to client)
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  },
   postcss: {
     plugins: {
       tailwindcss: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,14 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
+        "@types/ws": "^8.18.1",
         "blockly": "^11.0.0",
         "nuxt": "^3.11.2",
         "roslib": "^1.4.1",
         "vue": "^3.4.27",
-        "vue-router": "^4.3.2"
+        "vue-router": "^4.3.2",
+        "ws": "^8.19.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -153,6 +156,30 @@
       "integrity": "sha512-rWQkqXRESdjXtc+7NRfK9lASQjpXJu1ayp7qi1d23zZorY+wBHVLHHoVcMsEnkqEBWTFqbztO7/QdJFzyEcLTg==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2937,6 +2964,16 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2946,6 +2983,15 @@
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
       "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@unhead/dom": {
       "version": "1.9.10",
@@ -4047,6 +4093,18 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -4631,6 +4689,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -5052,9 +5123,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5597,6 +5669,20 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -5730,6 +5816,51 @@
       "integrity": "sha512-l0uy0kAoo6toCgVOYaAayqtPa2a1L15efxUMEnQebKwLQX2X0OpS6wMMQdc4juJXmxd9i40DuaUHq+mjIya9TQ==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -5995,16 +6126,38 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/fraction.js": {
@@ -6112,10 +6265,47 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-port-please": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
       "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
@@ -6241,6 +6431,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6283,6 +6485,33 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-unicode": {
@@ -6427,6 +6656,15 @@
       "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -7248,6 +7486,15 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -7694,6 +7941,26 @@
       "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "engines": {
         "node": "^16 || ^18 || >= 20"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -11520,6 +11787,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -11697,9 +11973,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@types/ws": "^8.18.1",
     "blockly": "^11.0.0",
     "nuxt": "^3.11.2",
     "roslib": "^1.4.1",
     "vue": "^3.4.27",
-    "vue-router": "^4.3.2"
+    "vue-router": "^4.3.2",
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+import ROSLIB from "roslib";
+import { useROS } from "~/composables/useROS";
+import type { DroneContext } from "~/composables/useClaudeChat";
+
+const { getROSURL } = useROS();
+
+const ros = ref<ROSLIB.Ros | null>(null);
+const rosConnected = ref(false);
+const droneContext = ref<DroneContext>({});
+
+// ROS connection
+const connectROS = () => {
+  const url = getROSURL();
+  ros.value = new ROSLIB.Ros({ url });
+
+  ros.value.on("connection", () => {
+    rosConnected.value = true;
+    subscribeToTopics();
+  });
+
+  ros.value.on("close", () => {
+    rosConnected.value = false;
+  });
+
+  ros.value.on("error", () => {
+    rosConnected.value = false;
+  });
+};
+
+const subscribeToTopics = () => {
+  if (!ros.value) return;
+
+  // Battery status
+  const batteryTopic = new ROSLIB.Topic({
+    ros: ros.value,
+    name: "/fmu/out/battery_status",
+    messageType: "px4_msgs/msg/BatteryStatus",
+  });
+
+  batteryTopic.subscribe((msg: any) => {
+    droneContext.value.battery = Math.round(msg.remaining * 100);
+  });
+
+  // Vehicle status
+  const statusTopic = new ROSLIB.Topic({
+    ros: ros.value,
+    name: "/fmu/out/vehicle_control_mode",
+    messageType: "px4_msgs/msg/VehicleControlMode",
+  });
+
+  statusTopic.subscribe((msg: any) => {
+    droneContext.value.armed = msg.flag_armed;
+    droneContext.value.mode = msg.flag_control_offboard_enabled
+      ? "Offboard"
+      : "Auto";
+  });
+
+  // Local position for altitude
+  const posTopic = new ROSLIB.Topic({
+    ros: ros.value,
+    name: "/fmu/out/vehicle_local_position",
+    messageType: "px4_msgs/msg/VehicleLocalPosition",
+  });
+
+  posTopic.subscribe((msg: any) => {
+    droneContext.value.altitude = -msg.z; // NED to altitude
+  });
+};
+
+onMounted(() => {
+  connectROS();
+});
+
+onUnmounted(() => {
+  if (ros.value) {
+    ros.value.close();
+  }
+});
+
+// Get simulator URL based on current hostname
+const simulatorUrl = computed(() => {
+  const hostname = process.client ? window.location.hostname : "localhost";
+  return `http://${hostname}:1337`;
+});
+</script>
+
+<template>
+  <div class="min-h-screen bg-base-100 flex flex-col">
+    <!-- Header -->
+    <div class="navbar bg-base-200 border-b border-base-content/10 px-4">
+      <div class="flex-1">
+        <NuxtLink to="/" class="btn btn-ghost text-xl gap-2">
+          <span>←</span>
+          <span>DEXI Chat</span>
+        </NuxtLink>
+      </div>
+      <div class="flex-none flex items-center gap-4">
+        <!-- Drone context badges -->
+        <div class="flex items-center gap-2 text-sm">
+          <div
+            :class="[
+              'badge',
+              rosConnected ? 'badge-success' : 'badge-error',
+            ]"
+          >
+            {{ rosConnected ? "ROS Connected" : "ROS Disconnected" }}
+          </div>
+          <div
+            v-if="droneContext.armed !== undefined"
+            :class="['badge', droneContext.armed ? 'badge-warning' : 'badge-ghost']"
+          >
+            {{ droneContext.armed ? "Armed" : "Disarmed" }}
+          </div>
+          <div v-if="droneContext.altitude !== undefined" class="badge badge-info">
+            {{ droneContext.altitude?.toFixed(1) }}m
+          </div>
+          <div v-if="droneContext.battery !== undefined" class="badge badge-ghost">
+            🔋 {{ droneContext.battery }}%
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main content: Chat left, Simulator right -->
+    <div class="flex-1 flex">
+      <!-- Chat panel -->
+      <div class="w-1/2 p-4 border-r border-base-content/10">
+        <ClaudeChat :drone-context="droneContext" class="h-[calc(100vh-5rem)]" />
+      </div>
+
+      <!-- Simulator panel -->
+      <div class="w-1/2 p-4">
+        <iframe
+          :src="simulatorUrl"
+          class="w-full h-[calc(100vh-5rem)] rounded-lg border border-base-content/10"
+          frameborder="0"
+        ></iframe>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/demos.vue
+++ b/pages/demos.vue
@@ -1,0 +1,259 @@
+<template>
+  <div class="min-h-screen bg-slate-50">
+    <!-- Header Section -->
+    <div class="bg-white border-b border-slate-200">
+      <div class="container mx-auto px-6 py-8">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-4">
+            <NuxtLink to="/" class="text-slate-500 hover:text-slate-700 transition-colors">
+              <span class="text-2xl">←</span>
+            </NuxtLink>
+            <h1 class="text-2xl font-semibold text-slate-900">Demo Missions</h1>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="container mx-auto px-6 py-12">
+
+      <!-- DroneBlocks Section -->
+      <div class="mb-8">
+        <button
+          @click="droneBlocksExpanded = !droneBlocksExpanded"
+          class="w-full flex items-center justify-between p-4 bg-white rounded-xl border border-slate-200 hover:border-slate-300 transition-all"
+        >
+          <div class="flex items-center gap-3">
+            <span class="text-3xl">🧩</span>
+            <div class="text-left">
+              <h2 class="text-2xl font-bold text-slate-900">DroneBlocks Missions</h2>
+              <p class="text-slate-600 text-sm">Visual block programming demos - click to open in DroneBlocks</p>
+            </div>
+          </div>
+          <span class="text-2xl text-slate-400 transition-transform" :class="{ 'rotate-180': droneBlocksExpanded }">
+            ▼
+          </span>
+        </button>
+      </div>
+
+      <div v-show="droneBlocksExpanded" class="section-content">
+        <!-- Basic Category -->
+        <div class="mb-12">
+          <div class="mb-6">
+            <h3 class="text-xl font-semibold text-slate-900 mb-2">Basic</h3>
+            <p class="text-slate-600">Simple missions to get started</p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div
+              v-for="demo in basicDemos"
+              :key="demo.id"
+              class="group card cursor-pointer"
+              @click="launchDemo(demo)"
+            >
+              <div class="card-content">
+                <div class="icon-wrapper bg-emerald-50">
+                  <span class="text-3xl">{{ getCategoryIcon('basic') }}</span>
+                </div>
+                <h3 class="card-title">{{ demo.name }}</h3>
+                <p class="card-description">{{ demo.description }}</p>
+                <div class="card-arrow">→</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Navigation Category -->
+        <div class="mb-12">
+          <div class="mb-6">
+            <h3 class="text-xl font-semibold text-slate-900 mb-2">Navigation</h3>
+            <p class="text-slate-600">Flight patterns and movement demos</p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div
+              v-for="demo in navigationDemos"
+              :key="demo.id"
+              class="group card cursor-pointer"
+              @click="launchDemo(demo)"
+            >
+              <div class="card-content">
+                <div class="icon-wrapper bg-blue-50">
+                  <span class="text-3xl">{{ getCategoryIcon('navigation') }}</span>
+                </div>
+                <h3 class="card-title">{{ demo.name }}</h3>
+                <p class="card-description">{{ demo.description }}</p>
+                <div class="card-arrow">→</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- AprilTag Category -->
+        <div class="mb-12">
+          <div class="mb-6">
+            <h3 class="text-xl font-semibold text-slate-900 mb-2">AprilTag</h3>
+            <p class="text-slate-600">Tag detection and response demos</p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div
+              v-for="demo in apriltagDemos"
+              :key="demo.id"
+              class="group card cursor-pointer"
+              @click="launchDemo(demo)"
+            >
+              <div class="card-content">
+                <div class="icon-wrapper bg-orange-50">
+                  <span class="text-3xl">{{ getCategoryIcon('apriltag') }}</span>
+                </div>
+                <h3 class="card-title">{{ demo.name }}</h3>
+                <p class="card-description">{{ demo.description }}</p>
+                <div class="card-arrow">→</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Python Section -->
+      <div class="mb-8">
+        <button
+          @click="pythonExpanded = !pythonExpanded"
+          class="w-full flex items-center justify-between p-4 bg-white rounded-xl border border-slate-200 hover:border-slate-300 transition-all"
+        >
+          <div class="flex items-center gap-3">
+            <span class="text-3xl">🐍</span>
+            <div class="text-left">
+              <h2 class="text-2xl font-bold text-slate-900">Python Missions</h2>
+              <p class="text-slate-600 text-sm">Python code examples - click to open in VS Code Server</p>
+            </div>
+          </div>
+          <span class="text-2xl text-slate-400 transition-transform" :class="{ 'rotate-180': pythonExpanded }">
+            ▼
+          </span>
+        </button>
+      </div>
+
+      <div v-show="pythonExpanded" class="section-content">
+        <!-- Python Missions -->
+        <div class="mb-12">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div
+              v-for="mission in pythonMissions"
+              :key="mission.id"
+              class="group card cursor-pointer"
+              @click="launchPythonMission(mission)"
+            >
+              <div class="card-content">
+                <div class="icon-wrapper bg-purple-50">
+                  <span class="text-3xl">🐍</span>
+                </div>
+                <h3 class="card-title">{{ mission.name }}</h3>
+                <p class="card-description">{{ mission.description }}</p>
+                <div class="card-arrow">↗</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { demos, getDemosByCategory, type Demo } from '~/assets/ts/demos';
+
+const hostname = process.client ? window.location.hostname : 'localhost';
+
+// Expand/collapse state
+const droneBlocksExpanded = ref(false);
+const pythonExpanded = ref(false);
+
+const basicDemos = computed(() => getDemosByCategory('basic'));
+const navigationDemos = computed(() => getDemosByCategory('navigation'));
+const apriltagDemos = computed(() => getDemosByCategory('apriltag'));
+
+interface PythonMission {
+  id: string;
+  name: string;
+  description: string;
+  folder: string;
+  file: string;
+}
+
+const pythonMissions: PythonMission[] = [
+  {
+    id: 'box-mission',
+    name: 'Box Mission',
+    description: 'Fly in a box pattern using MAVSDK Python. Great starting point for custom missions.',
+    folder: '/home/coder',
+    file: '/home/coder/dexi-mavsdk/missions/box_mission.py'
+  }
+];
+
+function getCategoryIcon(category: Demo['category']): string {
+  switch (category) {
+    case 'basic': return '🚀';
+    case 'navigation': return '🧭';
+    case 'apriltag': return '🏷️';
+    case 'advanced': return '⚡';
+    default: return '📦';
+  }
+}
+
+function launchDemo(demo: Demo) {
+  // Store demo data in localStorage for droneblocks to pick up
+  localStorage.setItem('droneblocks_demo', JSON.stringify({
+    id: demo.id,
+    name: demo.name,
+    blocklyXml: demo.blocklyXml
+  }));
+
+  // Open droneblocks in a new browser tab
+  window.open(`/droneblocks?demo=${demo.id}`, '_blank');
+}
+
+function launchPythonMission(mission: PythonMission) {
+  // Open code-server in a new tab with the folder and file
+  const url = `http://${hostname}:9999/?folder=${encodeURIComponent(mission.folder)}&file=${encodeURIComponent(mission.file)}`;
+  window.open(url, '_blank');
+}
+</script>
+
+<style scoped>
+.card {
+  @apply relative bg-white rounded-xl border border-slate-200 transition-all duration-200;
+  @apply hover:border-slate-300 hover:shadow-lg;
+}
+
+.card-content {
+  @apply p-6 flex flex-col h-full relative;
+}
+
+.icon-wrapper {
+  @apply w-14 h-14 rounded-lg flex items-center justify-center mb-4;
+  @apply transition-transform duration-200 group-hover:scale-110;
+}
+
+.card-title {
+  @apply text-lg font-semibold text-slate-900 mb-2;
+}
+
+.card-description {
+  @apply text-sm text-slate-600 leading-relaxed flex-grow;
+}
+
+.card-arrow {
+  @apply absolute bottom-5 right-5 text-slate-400 text-xl;
+  @apply opacity-0 transform translate-x-2;
+  @apply transition-all duration-200;
+  @apply group-hover:opacity-100 group-hover:translate-x-0;
+}
+
+.section-content {
+  @apply pl-4 border-l-2 border-slate-200 ml-4 mb-8;
+}
+
+.rotate-180 {
+  transform: rotate(180deg);
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -57,6 +57,20 @@
           </div>
         </NuxtLink>
 
+        <!-- Demo Missions -->
+        <NuxtLink to="/demos" class="group card">
+          <div class="card-content">
+            <div class="icon-wrapper bg-cyan-50">
+              <span class="text-3xl">🎯</span>
+            </div>
+            <h3 class="card-title">Demo Missions</h3>
+            <p class="card-description">
+              Pre-built example missions to learn from
+            </p>
+            <div class="card-arrow">→</div>
+          </div>
+        </NuxtLink>
+
         <!-- Node-RED -->
         <NuxtLink
           :to="`http://${hostname}:1880`"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -107,6 +107,20 @@
           </div>
         </NuxtLink>
 
+        <!-- DEXI Chat -->
+        <NuxtLink to="/chat" class="group card">
+          <div class="card-content">
+            <div class="icon-wrapper bg-violet-50">
+              <span class="text-3xl">🤖</span>
+            </div>
+            <h3 class="card-title">DEXI Chat</h3>
+            <p class="card-description">
+              AI assistant for natural language drone control
+            </p>
+            <div class="card-arrow">→</div>
+          </div>
+        </NuxtLink>
+
       </div>
 
       <!-- Section Title -->

--- a/server/api/chat.post.ts
+++ b/server/api/chat.post.ts
@@ -1,0 +1,189 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { ROS_TOOLS, executeRosTool } from "../utils/rosTools";
+
+const SYSTEM_PROMPT = `You are DEXI, an AI drone pilot assistant. You have direct access to ROS2 tools to discover and control the drone system.
+
+## Your Capabilities
+You can dynamically discover and interact with the ROS2 system:
+- get_topics: See all available data streams
+- get_services: See all available commands/actions
+- get_topic_type / get_service_type: Understand data formats
+- get_message_details: See the full structure of messages
+- call_service: Execute commands
+- subscribe_once: Read sensor data
+- publish_message: Send commands
+
+## How to Control the Drone
+For drone commands, use the DEXI execute_blockly_command service:
+- Service: /dexi/execute_blockly_command
+- Type: dexi_interfaces/srv/ExecuteBlocklyCommand
+- Fields: command (string), parameter (float), timeout (float)
+
+Available commands:
+- arm, disarm
+- takeoff (parameter = altitude in meters)
+- land
+- fly_forward, fly_backward, fly_left, fly_right (parameter = distance in meters)
+- fly_up, fly_down (parameter = distance in meters)
+- yaw_left, yaw_right (parameter = degrees)
+- circle (parameter = radius in meters)
+
+Example for takeoff to 3 meters:
+call_service("/dexi/execute_blockly_command", {command: "takeoff", parameter: 3.0, timeout: 30.0})
+
+## LED Control
+- Service: /dexi/led_service/set_led_ring_color
+- Fields: color (string) - red, green, blue, yellow, purple, cyan, white, etc.
+
+- Service: /dexi/led_service/set_led_effect
+- Fields: effect_name (string) - rainbow, blink, breathe, solid, off
+
+## Important Guidelines
+1. When asked to do something, USE YOUR TOOLS to actually do it
+2. If unsure about a service's format, use get_service_type and get_message_details first
+3. For drone operations, always use /dexi/execute_blockly_command (not raw PX4 commands)
+4. Be concise - execute first, then briefly confirm what you did
+5. If something fails, check get_services to see what's available`;
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface ChatRequest {
+  messages: ChatMessage[];
+  context?: {
+    armed?: boolean;
+    altitude?: number;
+    battery?: number;
+    mode?: string;
+  };
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig();
+  const apiKey = config.anthropicApiKey || process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw createError({
+      statusCode: 500,
+      message: "ANTHROPIC_API_KEY not configured",
+    });
+  }
+
+  const body = await readBody<ChatRequest>(event);
+
+  if (!body.messages || !Array.isArray(body.messages)) {
+    throw createError({
+      statusCode: 400,
+      message: "Invalid request: messages array required",
+    });
+  }
+
+  // Build system prompt with optional drone context
+  let systemPrompt = SYSTEM_PROMPT;
+  if (body.context) {
+    const ctx = body.context;
+    systemPrompt += `\n\n## Current Drone State`;
+    if (ctx.armed !== undefined) systemPrompt += `\n- Armed: ${ctx.armed}`;
+    if (ctx.altitude !== undefined)
+      systemPrompt += `\n- Altitude: ${ctx.altitude.toFixed(1)}m`;
+    if (ctx.battery !== undefined)
+      systemPrompt += `\n- Battery: ${ctx.battery}%`;
+    if (ctx.mode) systemPrompt += `\n- Mode: ${ctx.mode}`;
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  // Build messages for API
+  const apiMessages: Anthropic.MessageParam[] = body.messages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+
+  try {
+    // Initial request with tools
+    let response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: ROS_TOOLS as Anthropic.Tool[],
+      messages: apiMessages,
+    });
+
+    const toolResults: string[] = [];
+    let iterations = 0;
+    const maxIterations = 15; // Allow multiple tool calls for discovery
+
+    // Tool execution loop
+    while (response.stop_reason === "tool_use" && iterations < maxIterations) {
+      iterations++;
+
+      // Find tool use blocks
+      const toolUseBlocks = response.content.filter(
+        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+      );
+
+      // Execute each tool
+      const toolResultContents: Anthropic.ToolResultBlockParam[] = [];
+      for (const toolUse of toolUseBlocks) {
+        console.log(`[ROS Tool] ${toolUse.name}:`, JSON.stringify(toolUse.input));
+
+        const result = await executeRosTool(
+          toolUse.name,
+          toolUse.input as Record<string, any>
+        );
+
+        // Log truncated result
+        const logResult = result.length > 300 ? result.substring(0, 300) + "..." : result;
+        console.log(`[ROS Tool] Result: ${logResult}`);
+
+        toolResults.push(`[${toolUse.name}]: ${result}`);
+
+        toolResultContents.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: result,
+        });
+      }
+
+      // Continue conversation with tool results
+      apiMessages.push({
+        role: "assistant",
+        content: response.content,
+      });
+      apiMessages.push({
+        role: "user",
+        content: toolResultContents,
+      });
+
+      // Get next response
+      response = await client.messages.create({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 4096,
+        system: systemPrompt,
+        tools: ROS_TOOLS as Anthropic.Tool[],
+        messages: apiMessages,
+      });
+    }
+
+    // Extract final text response
+    const textContent = response.content.find(
+      (c): c is Anthropic.TextBlock => c.type === "text"
+    );
+    const text = textContent?.text || "";
+
+    return {
+      message: text,
+      toolResults,
+      usage: response.usage,
+    };
+  } catch (error: unknown) {
+    const err = error as Error & { status?: number };
+    console.error("Chat API error:", err);
+    throw createError({
+      statusCode: err.status || 500,
+      message: err.message || "Failed to get response from Claude",
+    });
+  }
+});

--- a/server/utils/rosTools.ts
+++ b/server/utils/rosTools.ts
@@ -1,0 +1,302 @@
+/**
+ * ROS Tools for Claude
+ *
+ * Dynamic tools that allow Claude to discover and interact with
+ * any ROS2 system without hardcoded knowledge.
+ */
+
+import { getConnectedClient } from "./rosbridge";
+
+// Tool definitions for Claude API
+export const ROS_TOOLS = [
+  {
+    name: "get_topics",
+    description: "List all available ROS topics. Use this to discover what data is available in the system.",
+    input_schema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "get_services",
+    description: "List all available ROS services. Use this to discover what actions/commands are available.",
+    input_schema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "get_topic_type",
+    description: "Get the message type for a specific topic. Use this before subscribing to understand the data format.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        topic: {
+          type: "string",
+          description: "The full topic path (e.g., /fmu/out/vehicle_status)",
+        },
+      },
+      required: ["topic"],
+    },
+  },
+  {
+    name: "get_service_type",
+    description: "Get the service type for a specific service. Use this to understand what arguments a service needs.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        service: {
+          type: "string",
+          description: "The full service path (e.g., /dexi/execute_blockly_command)",
+        },
+      },
+      required: ["service"],
+    },
+  },
+  {
+    name: "get_message_details",
+    description: "Get the full structure/fields of a message or service type. Use this to understand what data to send or expect.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          description: "The message type (e.g., dexi_interfaces/srv/ExecuteBlocklyCommand)",
+        },
+      },
+      required: ["type"],
+    },
+  },
+  {
+    name: "call_service",
+    description: "Call a ROS service with the given arguments. Use get_service_type and get_message_details first if unsure of the format.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        service: {
+          type: "string",
+          description: "The full service path",
+        },
+        args: {
+          type: "object",
+          description: "Arguments to pass to the service as a JSON object",
+        },
+        timeout: {
+          type: "number",
+          description: "Timeout in milliseconds (default: 30000)",
+        },
+      },
+      required: ["service"],
+    },
+  },
+  {
+    name: "subscribe_once",
+    description: "Subscribe to a topic and receive a single message. Useful for reading current sensor data or status.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        topic: {
+          type: "string",
+          description: "The full topic path",
+        },
+        msg_type: {
+          type: "string",
+          description: "The message type (use get_topic_type to find this)",
+        },
+        timeout: {
+          type: "number",
+          description: "Timeout in milliseconds (default: 5000)",
+        },
+      },
+      required: ["topic", "msg_type"],
+    },
+  },
+  {
+    name: "publish_message",
+    description: "Publish a message to a topic. Use get_topic_type and get_message_details to understand the format.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        topic: {
+          type: "string",
+          description: "The full topic path",
+        },
+        msg_type: {
+          type: "string",
+          description: "The message type",
+        },
+        message: {
+          type: "object",
+          description: "The message content as a JSON object",
+        },
+      },
+      required: ["topic", "msg_type", "message"],
+    },
+  },
+  {
+    name: "get_nodes",
+    description: "List all active ROS nodes in the system.",
+    input_schema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+];
+
+/**
+ * Execute a ROS tool by name
+ */
+export async function executeRosTool(
+  toolName: string,
+  args: Record<string, any>
+): Promise<string> {
+  try {
+    const client = await getConnectedClient();
+
+    switch (toolName) {
+      case "get_topics": {
+        const topics = await client.getTopics();
+        // Group by namespace for readability
+        const grouped = groupByNamespace(topics);
+        return formatGroupedList("Topics", grouped, topics.length);
+      }
+
+      case "get_services": {
+        const services = await client.getServices();
+        const grouped = groupByNamespace(services);
+        return formatGroupedList("Services", grouped, services.length);
+      }
+
+      case "get_topic_type": {
+        const type = await client.getTopicType(args.topic);
+        return type
+          ? `Topic ${args.topic} has type: ${type}`
+          : `Could not find type for topic ${args.topic}`;
+      }
+
+      case "get_service_type": {
+        const type = await client.getServiceType(args.service);
+        return type
+          ? `Service ${args.service} has type: ${type}`
+          : `Could not find type for service ${args.service}`;
+      }
+
+      case "get_message_details": {
+        const details = await client.getMessageDetails(args.type);
+        if (details?.typedefs && details.typedefs.length > 0) {
+          return formatMessageDetails(args.type, details.typedefs);
+        }
+        // Try service request details
+        const reqDetails = await client.getServiceRequestDetails(args.type);
+        if (reqDetails?.typedefs && reqDetails.typedefs.length > 0) {
+          return formatMessageDetails(args.type + " (Request)", reqDetails.typedefs);
+        }
+        return `Could not find details for type ${args.type}`;
+      }
+
+      case "call_service": {
+        const timeout = args.timeout || 30000;
+        const result = await client.callService(args.service, args.args || {}, timeout);
+        return `Service ${args.service} returned:\n${JSON.stringify(result, null, 2)}`;
+      }
+
+      case "subscribe_once": {
+        const timeout = args.timeout || 5000;
+        const msg = await client.subscribeOnce(args.topic, args.msg_type, timeout);
+        return `Message from ${args.topic}:\n${JSON.stringify(msg, null, 2)}`;
+      }
+
+      case "publish_message": {
+        await client.publish(args.topic, args.msg_type, args.message);
+        return `Published message to ${args.topic}`;
+      }
+
+      case "get_nodes": {
+        const nodes = await client.getNodes();
+        return `Active nodes (${nodes.length}):\n${nodes.join("\n")}`;
+      }
+
+      default:
+        return `Unknown tool: ${toolName}`;
+    }
+  } catch (error: any) {
+    return `Error executing ${toolName}: ${error.message}`;
+  }
+}
+
+/**
+ * Group items by their namespace prefix
+ */
+function groupByNamespace(items: string[]): Map<string, string[]> {
+  const grouped = new Map<string, string[]>();
+
+  for (const item of items) {
+    // Extract top-level namespace
+    const parts = item.split("/").filter(Boolean);
+    const namespace = parts.length > 1 ? `/${parts[0]}` : "/";
+
+    if (!grouped.has(namespace)) {
+      grouped.set(namespace, []);
+    }
+    grouped.get(namespace)!.push(item);
+  }
+
+  return grouped;
+}
+
+/**
+ * Format a grouped list for readable output
+ */
+function formatGroupedList(
+  title: string,
+  grouped: Map<string, string[]>,
+  total: number
+): string {
+  const lines: string[] = [`${title} (${total} total):`];
+
+  // Sort namespaces, prioritizing /dexi and /fmu
+  const sortedNamespaces = Array.from(grouped.keys()).sort((a, b) => {
+    if (a.startsWith("/dexi")) return -1;
+    if (b.startsWith("/dexi")) return 1;
+    if (a.startsWith("/fmu")) return -1;
+    if (b.startsWith("/fmu")) return 1;
+    return a.localeCompare(b);
+  });
+
+  for (const ns of sortedNamespaces) {
+    const items = grouped.get(ns)!;
+    lines.push(`\n${ns}/ (${items.length}):`);
+    for (const item of items.slice(0, 20)) {
+      lines.push(`  ${item}`);
+    }
+    if (items.length > 20) {
+      lines.push(`  ... and ${items.length - 20} more`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format message type details
+ */
+function formatMessageDetails(typeName: string, typedefs: any[]): string {
+  const lines: string[] = [`Message structure for ${typeName}:`];
+
+  for (const typedef of typedefs) {
+    lines.push(`\nType: ${typedef.type}`);
+    if (typedef.fieldnames && typedef.fieldtypes) {
+      lines.push("Fields:");
+      for (let i = 0; i < typedef.fieldnames.length; i++) {
+        const name = typedef.fieldnames[i];
+        const type = typedef.fieldtypes[i];
+        lines.push(`  - ${name}: ${type}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/server/utils/rosbridge.ts
+++ b/server/utils/rosbridge.ts
@@ -1,0 +1,265 @@
+/**
+ * Rosbridge WebSocket Client
+ *
+ * Connects to rosbridge_server and provides methods for:
+ * - Calling services
+ * - Subscribing to topics
+ * - Publishing messages
+ * - Querying rosapi for discovery
+ */
+
+import WebSocket from "ws";
+
+interface RosbridgeMessage {
+  op: string;
+  id?: string;
+  topic?: string;
+  type?: string;
+  msg?: any;
+  service?: string;
+  serviceType?: string;
+  args?: any;
+  result?: boolean;
+  values?: any;
+}
+
+export class RosbridgeClient {
+  private ws: WebSocket | null = null;
+  private url: string;
+  private pendingRequests: Map<string, {
+    resolve: (value: any) => void;
+    reject: (reason: any) => void;
+    timer: NodeJS.Timeout;
+  }> = new Map();
+  private subscriptionHandlers: Map<string, (msg: any) => void> = new Map();
+  private messageId = 0;
+  private connected = false;
+  private reconnecting = false;
+
+  constructor(url: string = "ws://localhost:9090") {
+    this.url = url;
+  }
+
+  async connect(timeout: number = 5000): Promise<void> {
+    if (this.connected && this.ws?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`Connection timeout to ${this.url}`));
+      }, timeout);
+
+      this.ws = new WebSocket(this.url);
+
+      this.ws.on("open", () => {
+        clearTimeout(timer);
+        this.connected = true;
+        console.log(`Connected to rosbridge at ${this.url}`);
+        resolve();
+      });
+
+      this.ws.on("error", (err) => {
+        clearTimeout(timer);
+        this.connected = false;
+        reject(err);
+      });
+
+      this.ws.on("close", () => {
+        this.connected = false;
+        console.log("Rosbridge connection closed");
+      });
+
+      this.ws.on("message", (data: WebSocket.Data) => {
+        this.handleMessage(data);
+      });
+    });
+  }
+
+  private handleMessage(data: WebSocket.Data): void {
+    try {
+      const msg: RosbridgeMessage = JSON.parse(data.toString());
+
+      // Handle service response
+      if (msg.op === "service_response" && msg.id) {
+        const pending = this.pendingRequests.get(msg.id);
+        if (pending) {
+          clearTimeout(pending.timer);
+          this.pendingRequests.delete(msg.id);
+          pending.resolve(msg.values ?? msg.result);
+        }
+      }
+
+      // Handle topic message (subscription)
+      if (msg.op === "publish" && msg.topic) {
+        const handler = this.subscriptionHandlers.get(msg.topic);
+        if (handler) {
+          handler(msg.msg);
+        }
+      }
+    } catch (e) {
+      console.error("Failed to parse rosbridge message:", e);
+    }
+  }
+
+  disconnect(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+      this.connected = false;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private send(msg: RosbridgeMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket not connected");
+    }
+    this.ws.send(JSON.stringify(msg));
+  }
+
+  private generateId(): string {
+    return `req_${++this.messageId}_${Date.now()}`;
+  }
+
+  /**
+   * Call a ROS service
+   */
+  async callService(
+    service: string,
+    args: any = {},
+    timeout: number = 30000
+  ): Promise<any> {
+    await this.connect();
+    const id = this.generateId();
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Service call timeout: ${service}`));
+      }, timeout);
+
+      this.pendingRequests.set(id, { resolve, reject, timer });
+
+      this.send({
+        op: "call_service",
+        id,
+        service,
+        args,
+      });
+    });
+  }
+
+  /**
+   * Subscribe to a topic and get a single message
+   */
+  async subscribeOnce(
+    topic: string,
+    msgType: string,
+    timeout: number = 5000
+  ): Promise<any> {
+    await this.connect();
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.unsubscribe(topic);
+        this.subscriptionHandlers.delete(topic);
+        reject(new Error(`Subscribe timeout: ${topic}`));
+      }, timeout);
+
+      this.subscriptionHandlers.set(topic, (msg) => {
+        clearTimeout(timer);
+        this.unsubscribe(topic);
+        this.subscriptionHandlers.delete(topic);
+        resolve(msg);
+      });
+
+      this.send({
+        op: "subscribe",
+        topic,
+        type: msgType,
+      });
+    });
+  }
+
+  /**
+   * Unsubscribe from a topic
+   */
+  unsubscribe(topic: string): void {
+    if (this.isConnected()) {
+      this.send({ op: "unsubscribe", topic });
+    }
+  }
+
+  /**
+   * Publish a message to a topic
+   */
+  async publish(topic: string, msgType: string, msg: any): Promise<void> {
+    await this.connect();
+    this.send({
+      op: "publish",
+      topic,
+      type: msgType,
+      msg,
+    });
+  }
+
+  // ============ ROSAPI Convenience Methods ============
+
+  async getTopics(): Promise<string[]> {
+    const result = await this.callService("/rosapi/topics", {});
+    return result?.topics || [];
+  }
+
+  async getServices(): Promise<string[]> {
+    const result = await this.callService("/rosapi/services", {});
+    return result?.services || [];
+  }
+
+  async getTopicType(topic: string): Promise<string> {
+    const result = await this.callService("/rosapi/topic_type", { topic });
+    return result?.type || "";
+  }
+
+  async getServiceType(service: string): Promise<string> {
+    const result = await this.callService("/rosapi/service_type", { service });
+    return result?.type || "";
+  }
+
+  async getMessageDetails(type: string): Promise<any> {
+    const result = await this.callService("/rosapi/message_details", { type });
+    return result;
+  }
+
+  async getServiceRequestDetails(type: string): Promise<any> {
+    const result = await this.callService("/rosapi/service_request_details", { type });
+    return result;
+  }
+
+  async getNodes(): Promise<string[]> {
+    const result = await this.callService("/rosapi/nodes", {});
+    return result?.nodes || [];
+  }
+}
+
+// Singleton instance
+let clientInstance: RosbridgeClient | null = null;
+
+export function getRosbridgeClient(url?: string): RosbridgeClient {
+  if (!clientInstance) {
+    const rosbridgeUrl = url || process.env.ROSBRIDGE_URL || "ws://localhost:9090";
+    clientInstance = new RosbridgeClient(rosbridgeUrl);
+  }
+  return clientInstance;
+}
+
+export async function getConnectedClient(url?: string): Promise<RosbridgeClient> {
+  const client = getRosbridgeClient(url);
+  if (!client.isConnected()) {
+    await client.connect();
+  }
+  return client;
+}


### PR DESCRIPTION
## Add Claude Chat with Native ROS Tool Integration

### Summary
Adds an AI-powered chat interface that allows users to control the drone using natural language. Claude discovers and interacts with the ROS2 system dynamically, requiring no prior knowledge of ROS from the user.

### Features
- **Split-screen chat page** (`/chat`) with chat on left, Unity simulator on right
- **Natural language drone control** - "takeoff to 5 meters", "set LED to rainbow", "fly forward 2 meters"
- **Dynamic ROS discovery** - Claude can inspect topics, services, and message types at runtime
- **Real-time execution** - Commands are executed via rosbridge, not just explained

### Architecture
```
User Chat → Nuxt API → Claude API (with ROS tools)
                            ↓
                    Tool execution
                            ↓
                    rosbridge.ts (WebSocket)
                            ↓
                    rosbridge_server:9090 → ROS2
```

### ROS Tools Available to Claude
| Tool | Purpose |
|------|---------|
| `get_topics` / `get_services` | Discover available data and commands |
| `get_topic_type` / `get_service_type` | Understand message formats |
| `get_message_details` | Inspect full message structure |
| `call_service` | Execute any ROS service |
| `subscribe_once` | Read sensor data |
| `publish_message` | Send commands to topics |

### Drone Control
Claude uses `/dexi/execute_blockly_command` for all flight operations:
- `arm`, `disarm`, `takeoff`, `land`
- `fly_forward`, `fly_backward`, `fly_left`, `fly_right`
- `fly_up`, `fly_down`, `yaw_left`, `yaw_right`
- `circle`, `flip_forward`, etc.

### Configuration
Requires `ANTHROPIC_API_KEY` environment variable or in `nuxt.config.ts` runtime config.

### Testing
1. Start the docker stack (`docker compose up`)
2. Navigate to `http://localhost:3000/chat`
3. Try commands like:
   - "What services are available?"
   - "Set the LED to blue"
   - "Arm the drone and takeoff to 3 meters"
