### PR TITLE
Add flip category with flip blocks

### DIFF
--- a/assets/ts/flip.ts
+++ b/assets/ts/flip.ts
@@ -1,0 +1,89 @@
+import * as Blockly from 'blockly/core';
+import {JavascriptGenerator, javascriptGenerator} from 'blockly/javascript';
+
+export class Flip {
+  constructor() {
+    Blockly.defineBlocksWithJsonArray([
+      {
+        "type": "flip_forward",
+        "message0": "flip forward",
+        "colour": "#FF6B6B",
+        "previousStatement": null,
+        "nextStatement": null,
+        "tooltip": "Perform a forward flip",
+        "helpUrl": ""
+      },
+      {
+        "type": "flip_backward",
+        "message0": "flip backward",
+        "colour": "#FF6B6B",
+        "previousStatement": null,
+        "nextStatement": null,
+        "tooltip": "Perform a backward flip",
+        "helpUrl": ""
+      },
+      {
+        "type": "flip_left",
+        "message0": "flip left",
+        "colour": "#FF6B6B",
+        "previousStatement": null,
+        "nextStatement": null,
+        "tooltip": "Perform a left flip",
+        "helpUrl": ""
+      },
+      {
+        "type": "flip_right",
+        "message0": "flip right",
+        "colour": "#FF6B6B",
+        "previousStatement": null,
+        "nextStatement": null,
+        "tooltip": "Perform a right flip",
+        "helpUrl": ""
+      }
+    ]);
+
+    javascriptGenerator.forBlock['flip_forward'] = function(block: Blockly.Block, generator: JavascriptGenerator) {
+      return `
+// Flip forward
+offboardCommand.publish({
+  command: 'flip_forward',
+  distance_or_degrees: 0.0
+});
+await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for flip to complete
+`;
+    }
+
+    javascriptGenerator.forBlock['flip_backward'] = function(block: Blockly.Block, generator: JavascriptGenerator) {
+      return `
+// Flip backward
+offboardCommand.publish({
+  command: 'flip_backward',
+  distance_or_degrees: 0.0
+});
+await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for flip to complete
+`;
+    }
+
+    javascriptGenerator.forBlock['flip_left'] = function(block: Blockly.Block, generator: JavascriptGenerator) {
+      return `
+// Flip left
+offboardCommand.publish({
+  command: 'flip_left',
+  distance_or_degrees: 0.0
+});
+await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for flip to complete
+`;
+    }
+
+    javascriptGenerator.forBlock['flip_right'] = function(block: Blockly.Block, generator: JavascriptGenerator) {
+      return `
+// Flip right
+offboardCommand.publish({
+  command: 'flip_right',
+  distance_or_degrees: 0.0
+});
+await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for flip to complete
+`;
+    }
+  }
+}

--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -4,6 +4,7 @@ import * as Blockly from 'blockly/core';
 import { Navigation } from '~/assets/ts/navigation';
 import { LED } from '~/assets/ts/led';
 import { AprilTag } from '~/assets/ts/apriltag';
+import { Flip } from '~/assets/ts/flip';
 import { javascriptGenerator } from 'blockly/javascript';
 import ROSLIB from 'roslib';
 import { useROS } from '~/composables/useROS';
@@ -22,6 +23,7 @@ const router = useRouter();
 const navigation = new Navigation();
 const led = new LED();
 const apriltag = new AprilTag();
+const flip = new Flip();
 
 // Tutorial system
 const tutorial = useTutorial();
@@ -277,6 +279,12 @@ const options = {
           </value>
         </block>
       </category>
+    <category name="Flip" colour="#FF6B6B">
+      <block type="flip_forward"></block>
+      <block type="flip_backward"></block>
+      <block type="flip_left"></block>
+      <block type="flip_right"></block>
+    </category>
     <category name="LED" colour="#9C27B0">
       <block type="led_effect">
         <field name="effect">rainbow</field>


### PR DESCRIPTION
Closes #16

Adds a new Flip category to the DroneBlocks interface with four flip commands:
- flip forward
- flip backward
- flip left
- flip right

Each flip block publishes the appropriate command to the offboard command topic and waits 2 seconds for the flip maneuver to complete.

The implementation follows the existing pattern used for navigation, LED, and AprilTag blocks.

Generated with [Claude Code](https://claude.ai/code)