### PR TITLE
Switch keyboard control to continuous velocity setpoints

### DIFF
--- a/pages/scan.vue
+++ b/pages/scan.vue
@@ -97,7 +97,6 @@ const copyBlocks = async () => {
         ref="fileInput"
         type="file"
         accept="image/*"
-        capture="environment"
         @change="handleFileSelect"
         class="hidden-input"
       />


### PR DESCRIPTION
## Summary
- Replace discrete position commands (fly_forward 1m, fly_up 1m) with continuous velocity setpoint control (`set_velocity_body` / `stop_velocity`)
- Keys are held for continuous movement published at 10Hz, with multi-key support for diagonal flight and combined translation+yaw
- Window blur safety auto-releases all keys and sends stop_velocity to prevent stuck movement

## Details
- **Arrows**: body-frame XY at 1.0 m/s
- **W/S**: altitude up/down at 0.3 m/s
- **A/D**: yaw left/right at 45 deg/s
- **T**: one-shot offboard_takeoff to 2m
- **L**: stop heartbeat + land

Requires the velocity setpoint control feature in `dexi_offboard` ([DroneBlocks/dexi_offboard#feature/velocity-setpoint-control](https://github.com/DroneBlocks/dexi_offboard/tree/feature/velocity-setpoint-control)).

## Test plan
- [ ] Open Keyboard Control widget from hamburger menu
- [ ] Click Start Control, press T to takeoff
- [ ] Hold arrow keys — verify smooth continuous movement (not discrete hops)
- [ ] Hold multiple keys simultaneously — verify diagonal/combined movement
- [ ] Release all keys — verify drone holds position
- [ ] Tab away from window — verify drone stops (no stuck velocity)
- [ ] Press L to land