### PR TITLE
Switch keyboard control to continuous velocity commands

### DIFF
--- a/pages/scan.vue
+++ b/pages/scan.vue
@@ -97,7 +97,6 @@ const copyBlocks = async () => {
         ref="fileInput"
         type="file"
         accept="image/*"
-        capture="environment"
         @change="handleFileSelect"
         class="hidden-input"
       />


### PR DESCRIPTION
## Summary
- Replaces discrete position commands (fly_forward 1m, fly_up 1m) with continuous velocity commands published at 10Hz while keys are held
- Adds `set_velocity_body` and `stop_velocity` commands for smooth, responsive drone control
- Supports simultaneous key holds (e.g., forward + right for diagonal movement)
- Automatically stops velocity when keys are released, window loses focus, or widget is closed
- Also removes `capture="environment"` from scan page file input to allow photo library selection on mobile

## Test plan
- [ ] Verify keyboard control connects to rosbridge and activates
- [ ] Hold arrow keys and confirm smooth continuous movement
- [ ] Release all keys and confirm drone stops (position hold)
- [ ] Hold multiple keys simultaneously (e.g., ↑ + →) for diagonal movement
- [ ] Test T for takeoff and L for land still work as one-shot commands
- [ ] Verify velocity stops when window loses focus or widget is closed