### PR TITLE
Fix rosbridge WebSocket URL for HTTPS/tunnel access

### DIFF
--- a/composables/useROS.ts
+++ b/composables/useROS.ts
@@ -1,10 +1,12 @@
 export const useROS = () => {
   const getROSURL = (): string => {
-    // Use the current hostname with WebSocket protocol and port 9090
-    // Use secure WebSocket (wss://) when page is served over HTTPS
     const hostname = window.location.hostname
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    return `${protocol}//${hostname}:9090`
+    const isSecure = window.location.protocol === 'https:'
+    const protocol = isSecure ? 'wss:' : 'ws:'
+    // Over HTTPS (e.g. Cloudflare tunnel), route through nginx reverse proxy
+    // Over HTTP (local network), connect directly to rosbridge port
+    const target = isSecure ? '/rosbridge' : ':9090'
+    return `${protocol}//${hostname}${target}`
   }
 
   const isDevMode = (): boolean => {


### PR DESCRIPTION
## Summary
- When served over HTTPS (e.g. Cloudflare tunnel), route rosbridge WebSocket through nginx at `/rosbridge` instead of connecting directly to port 9090
- Browsers block `ws://` connections from HTTPS pages (mixed content), so this uses `wss://hostname/rosbridge` which goes through the nginx reverse proxy
- Local HTTP access unchanged — still connects to `ws://hostname:9090` directly

## Test plan
- [ ] Access DroneBlocks over Cloudflare tunnel (HTTPS) — verify rosbridge connects via `/rosbridge` path
- [ ] Access DroneBlocks locally (HTTP) — verify rosbridge connects to `:9090` directly
- [ ] Verify no mixed content browser errors in either mode