### PR TITLE
Fix chat page missing simulator split view

### DIFF
--- a/components/AprilTagVisualizer.vue
+++ b/components/AprilTagVisualizer.vue
@@ -1,20 +1,11 @@
 <template>
   <div class="apriltag-visualizer">
-    <!-- Stability Indicator -->
-    <div class="stability-section">
-      <div
-        class="stability-indicator"
-        :class="stabilityClass"
-      >
-        {{ stabilityText }}
-      </div>
-      <div class="stability-description">{{ stabilityDescription }}</div>
-      <div
-        class="ready-banner"
-        :class="readyBannerClass"
-      >
-        {{ readyBannerText }}
-      </div>
+    <!-- Compact Stability Banner -->
+    <div class="stability-bar" :class="readyBannerClass">
+      <div class="stability-dot" :class="stabilityClass"></div>
+      <span class="stability-bar-text">{{ stabilityText }}</span>
+      <span class="stability-bar-sep">|</span>
+      <span class="stability-bar-desc">{{ stabilityDescription }}</span>
     </div>
 
     <!-- Position Display -->
@@ -95,6 +86,38 @@
       </div>
     </div>
 
+    <!-- Sensor Fusion Status -->
+    <div class="data-section">
+      <h3 class="section-title">Sensor Fusion (EKF2)</h3>
+      <div class="fusion-grid">
+        <div class="fusion-item" :class="fusionOpticalFlow ? 'active' : 'inactive'">
+          <span class="fusion-indicator" :class="fusionOpticalFlow ? 'on' : 'off'"></span>
+          <div>
+            <span class="fusion-label">Optical Flow</span>
+            <span class="fusion-detail">~50Hz velocity</span>
+          </div>
+        </div>
+        <div class="fusion-item" :class="fusionRangeHeight ? 'active' : 'inactive'">
+          <span class="fusion-indicator" :class="fusionRangeHeight ? 'on' : 'off'"></span>
+          <div>
+            <span class="fusion-label">Range Sensor</span>
+            <span class="fusion-detail">~50Hz altitude</span>
+          </div>
+        </div>
+        <div class="fusion-item" :class="fusionEvPos ? 'active' : 'inactive'">
+          <span class="fusion-indicator" :class="fusionEvPos ? 'on' : 'off'"></span>
+          <div>
+            <span class="fusion-label">AprilTag Vision</span>
+            <span class="fusion-detail">{{ visionRate }} position</span>
+          </div>
+        </div>
+      </div>
+      <div class="fusion-altitude" v-if="ekfAltitude !== null">
+        <span class="fusion-alt-label">EKF2 Altitude</span>
+        <span class="fusion-alt-value">{{ ekfAltitude }} m</span>
+      </div>
+    </div>
+
     <!-- Position History Canvas -->
     <div class="data-section">
       <h3 class="section-title">Position History (10s)</h3>
@@ -116,9 +139,9 @@ const props = defineProps<{
   ros: ROSLIB.Ros | null
 }>()
 
-// Configuration
-const TARGET_TAG_ID = 0
+// Configuration — track any detected tag, not just one hardcoded ID
 const TAG_FAMILY = '36h11'
+const activeTagId = ref<number | null>(null)
 const STABILITY_WINDOW_MS = 2000
 const STABLE_THRESHOLD_M = 0.05
 const MODERATE_THRESHOLD_M = 0.15
@@ -151,10 +174,20 @@ let lastTfTime = 0
 // Canvas ref
 const historyCanvas = ref<HTMLCanvasElement | null>(null)
 
+// Sensor fusion state
+const fusionEvPos = ref(false)
+const fusionOpticalFlow = ref(false)
+const fusionRangeHeight = ref(false)
+const ekfAltitude = ref<string | null>(null)
+const visionRate = ref('--')
+const visionMsgTimes: number[] = []
+
 // Subscribers
 let tfSubscriber: ROSLIB.Topic | null = null
 let detectionSubscriber: ROSLIB.Topic | null = null
 let localPosSubscriber: ROSLIB.Topic | null = null
+let estimatorSubscriber: ROSLIB.Topic | null = null
+let visionOdomSubscriber: ROSLIB.Topic | null = null
 let updateInterval: number | null = null
 
 // Heading and position from PX4 (for NED calculation)
@@ -220,6 +253,26 @@ const handleLocalPositionMessage = (msg: any) => {
   droneY = msg.y || 0
   droneZ = msg.z || 0
   headingValid = true
+  // NED: z is negative when above ground
+  ekfAltitude.value = (-droneZ).toFixed(2)
+}
+
+// Handle estimator status flags
+const handleEstimatorFlags = (msg: any) => {
+  fusionEvPos.value = msg.cs_ev_pos || false
+  fusionOpticalFlow.value = msg.cs_opt_flow || false
+  fusionRangeHeight.value = msg.cs_rng_hgt || false
+}
+
+// Handle vision odometry messages (to track publish rate)
+const handleVisionOdom = (_msg: any) => {
+  const now = Date.now()
+  visionMsgTimes.push(now)
+  while (visionMsgTimes.length > 0 && visionMsgTimes[0] < now - 2000) {
+    visionMsgTimes.shift()
+  }
+  const rate = visionMsgTimes.length / 2
+  visionRate.value = `~${rate.toFixed(0)}Hz`
 }
 
 // Handle TF messages and compute NED position
@@ -230,7 +283,9 @@ const handleTfMessage = (msg: any) => {
     const childFrame = transform.child_frame_id
     if (childFrame && childFrame.includes(':')) {
       const [family, id] = childFrame.split(':')
-      if (family.includes(TAG_FAMILY) && parseInt(id) === TARGET_TAG_ID) {
+      const parsedId = parseInt(id)
+      if (family.includes(TAG_FAMILY) && !isNaN(parsedId)) {
+        activeTagId.value = parsedId
         const t = transform.transform.translation
         tfX.value = t.x.toFixed(3)
         tfY.value = t.y.toFixed(3)
@@ -299,7 +354,7 @@ const handleDetectionMessage = (msg: any) => {
   }
 
   for (const detection of msg.detections) {
-    if (detection.id === TARGET_TAG_ID) {
+    if (activeTagId.value === null || detection.id === activeTagId.value) {
       tagId.value = String(detection.id)
       tagFamily.value = detection.family || TAG_FAMILY
       decisionMargin.value = detection.decision_margin ? detection.decision_margin.toFixed(1) : '--'
@@ -481,7 +536,23 @@ const setupSubscriptions = () => {
   })
   localPosSubscriber.subscribe(handleLocalPositionMessage)
 
-  console.log('AprilTagVisualizer: Subscribed to /tf, /apriltag_detections, /fmu/out/vehicle_local_position')
+  // Subscribe to estimator status flags (for sensor fusion indicators)
+  estimatorSubscriber = new ROSLIB.Topic({
+    ros: props.ros,
+    name: '/fmu/out/estimator_status_flags',
+    messageType: 'px4_msgs/msg/EstimatorStatusFlags'
+  })
+  estimatorSubscriber.subscribe(handleEstimatorFlags)
+
+  // Subscribe to visual odometry (to track publish rate)
+  visionOdomSubscriber = new ROSLIB.Topic({
+    ros: props.ros,
+    name: '/fmu/in/vehicle_visual_odometry',
+    messageType: 'px4_msgs/msg/VehicleOdometry'
+  })
+  visionOdomSubscriber.subscribe(handleVisionOdom)
+
+  console.log('AprilTagVisualizer: Subscribed to /tf, /apriltag_detections, /fmu/out/vehicle_local_position, /fmu/out/estimator_status_flags, /fmu/in/vehicle_visual_odometry')
 }
 
 // Watch for ROS connection changes
@@ -502,6 +573,8 @@ onBeforeUnmount(() => {
   if (tfSubscriber) tfSubscriber.unsubscribe()
   if (detectionSubscriber) detectionSubscriber.unsubscribe()
   if (localPosSubscriber) localPosSubscriber.unsubscribe()
+  if (estimatorSubscriber) estimatorSubscriber.unsubscribe()
+  if (visionOdomSubscriber) visionOdomSubscriber.unsubscribe()
   if (updateInterval) clearInterval(updateInterval)
 })
 </script>
@@ -510,113 +583,92 @@ onBeforeUnmount(() => {
 .apriltag-visualizer {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  padding: 1rem;
+  gap: 0.75rem;
+  padding: 0;
   background: #111827;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-.stability-section {
-  text-align: center;
-  padding: 1.5rem;
-  background: #1f2937;
-  border-radius: 0.5rem;
-}
-
-.stability-indicator {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  margin: 0 auto 1rem;
+/* Compact stability bar */
+.stability-bar {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  font-weight: bold;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
   transition: all 0.3s;
 }
 
-.stability-no-tag {
-  background: #374151;
-  border: 3px solid #4b5563;
+.stability-bar.not-ready {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+}
+
+.stability-bar.caution {
+  background: rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+
+.stability-bar.ready {
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+}
+
+.stability-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.stability-dot.stability-no-tag { background: #4b5563; }
+.stability-dot.stability-unstable { background: #ef4444; box-shadow: 0 0 6px rgba(239, 68, 68, 0.5); }
+.stability-dot.stability-moderate { background: #f59e0b; box-shadow: 0 0 6px rgba(245, 158, 11, 0.5); }
+.stability-dot.stability-stable { background: #22c55e; box-shadow: 0 0 6px rgba(34, 197, 94, 0.5); }
+
+.stability-bar-text {
+  font-weight: 700;
+  color: #e5e7eb;
+}
+
+.stability-bar-sep {
+  color: #4b5563;
+}
+
+.stability-bar-desc {
   color: #9ca3af;
-}
-
-.stability-unstable {
-  background: rgba(239, 68, 68, 0.2);
-  border: 3px solid #ef4444;
-  color: #ef4444;
-}
-
-.stability-moderate {
-  background: rgba(245, 158, 11, 0.2);
-  border: 3px solid #f59e0b;
-  color: #f59e0b;
-}
-
-.stability-stable {
-  background: rgba(34, 197, 94, 0.2);
-  border: 3px solid #22c55e;
-  color: #22c55e;
-}
-
-.stability-description {
-  font-size: 0.875rem;
-  color: #9ca3af;
-  margin-bottom: 1rem;
-}
-
-.ready-banner {
-  padding: 0.75rem 1rem;
-  border-radius: 0.375rem;
-  font-weight: bold;
-  font-size: 0.875rem;
-}
-
-.ready-banner.not-ready {
-  background: rgba(239, 68, 68, 0.2);
-  border: 2px solid #ef4444;
-  color: #ef4444;
-}
-
-.ready-banner.caution {
-  background: rgba(245, 158, 11, 0.2);
-  border: 2px solid #f59e0b;
-  color: #f59e0b;
-}
-
-.ready-banner.ready {
-  background: rgba(34, 197, 94, 0.2);
-  border: 2px solid #22c55e;
-  color: #22c55e;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .data-section {
   background: #1f2937;
-  border-radius: 0.5rem;
-  padding: 1rem;
+  border-radius: 0.375rem;
+  padding: 0.625rem;
 }
 
 .section-title {
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   text-transform: uppercase;
   color: #6b7280;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   border-bottom: 1px solid #374151;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.375rem;
 }
 
 .data-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 .data-item {
   text-align: center;
   background: #374151;
-  padding: 0.75rem;
+  padding: 0.5rem;
   border-radius: 0.375rem;
 }
 
@@ -629,7 +681,7 @@ onBeforeUnmount(() => {
 
 .data-value {
   display: block;
-  font-size: 1.25rem;
+  font-size: 1.0625rem;
   font-weight: bold;
   font-family: 'SF Mono', Monaco, monospace;
 }
@@ -648,14 +700,14 @@ onBeforeUnmount(() => {
 
 .quality-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
 }
 
 .quality-item {
   background: #374151;
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.5rem;
   border-radius: 0.375rem;
 }
 
@@ -690,7 +742,7 @@ onBeforeUnmount(() => {
 
 .history-canvas {
   width: 100%;
-  height: 120px;
+  height: 80px;
   background: #1f2937;
   border-radius: 0.375rem;
 }
@@ -718,4 +770,81 @@ onBeforeUnmount(() => {
 .legend-item.north::before { background: #ef4444; }
 .legend-item.east::before { background: #22c55e; }
 .legend-item.down::before { background: #3b82f6; }
+
+.fusion-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.375rem;
+}
+
+.fusion-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.375rem;
+  transition: all 0.3s;
+}
+
+.fusion-item.active {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.fusion-item.inactive {
+  background: #374151;
+  border: 1px solid #4b5563;
+}
+
+.fusion-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: all 0.3s;
+}
+
+.fusion-indicator.on {
+  background: #22c55e;
+  box-shadow: 0 0 8px rgba(34, 197, 94, 0.5);
+}
+
+.fusion-indicator.off {
+  background: #4b5563;
+}
+
+.fusion-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #e5e7eb;
+}
+
+.fusion-detail {
+  display: block;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.fusion-altitude {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  background: #374151;
+  border-radius: 0.375rem;
+}
+
+.fusion-alt-label {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.fusion-alt-value {
+  font-size: 1.125rem;
+  font-weight: bold;
+  font-family: 'SF Mono', Monaco, monospace;
+  color: #3b82f6;
+}
 </style>

--- a/components/MainMenu.vue
+++ b/components/MainMenu.vue
@@ -82,15 +82,13 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import ROSLIB from 'roslib'
-import { useROS } from '~/composables/useROS'
+import { ref } from 'vue'
+import { useDexiPlatform } from '~/composables/useDexiPlatform'
 
 const isOpen = ref(false)
 const cameraInverted = ref(false) // Camera displays right-side up by default
-const keyboardControlAvailable = ref(false)
 
-const { getROSURL, isDevMode } = useROS()
+const { keyboardControlEnabled: keyboardControlAvailable } = useDexiPlatform()
 
 const openGitHub = () => {
   window.open('https://github.com/droneblocks', '_blank')
@@ -113,45 +111,6 @@ const openKeyboardControl = () => {
   emit('open-keyboard-control')
   isOpen.value = false
 }
-
-const checkKeyboardControlAvailability = () => {
-  // In dev mode, always enable keyboard control for UI testing
-  if (isDevMode()) {
-    keyboardControlAvailable.value = true
-    return
-  }
-
-  try {
-    const ros = new ROSLIB.Ros({
-      url: getROSURL()
-    })
-
-    ros.on('connection', () => {
-      const paramClient = new ROSLIB.Param({
-        ros: ros,
-        name: '/dexi/px4_offboard_manager:keyboard_control_enabled'
-      })
-
-      paramClient.get((value) => {
-        keyboardControlAvailable.value = value === true
-        ros.close()
-      }, (error) => {
-        keyboardControlAvailable.value = false
-        ros.close()
-      })
-    })
-
-    ros.on('error', () => {
-      keyboardControlAvailable.value = false
-    })
-  } catch (error) {
-    keyboardControlAvailable.value = false
-  }
-}
-
-onMounted(() => {
-  checkKeyboardControlAvailability()
-})
 
 defineExpose({
   cameraInverted

--- a/composables/useDexiPlatform.ts
+++ b/composables/useDexiPlatform.ts
@@ -25,8 +25,8 @@ const queryParam = (ros: ROSLIB.Ros, name: string): Promise<any> => {
 const loadPlatformParams = async (ros: ROSLIB.Ros) => {
   try {
     const [platformValue, keyboardValue] = await Promise.allSettled([
-      queryParam(ros, '/rosbridge_websocket:dexi_platform'),
-      queryParam(ros, '/rosbridge_websocket:dexi_keyboard_control'),
+      queryParam(ros, '/dexi_platform_params:dexi_platform'),
+      queryParam(ros, '/dexi_platform_params:dexi_keyboard_control'),
     ])
 
     if (platformValue.status === 'fulfilled' && platformValue.value) {

--- a/composables/useDexiPlatform.ts
+++ b/composables/useDexiPlatform.ts
@@ -3,8 +3,10 @@ import ROSLIB from 'roslib'
 
 export type DexiPlatform = 'ark_cm4' | 'cm5' | 'pi5' | 'unity_sim' | 'jetson' | 'unknown'
 
-const platform = ref<DexiPlatform>('unknown')
-const keyboardControlEnabled = ref(false)
+const isDevMode = process.env.NODE_ENV === 'development'
+
+const platform = ref<DexiPlatform>(isDevMode ? 'unity_sim' : 'unknown')
+const keyboardControlEnabled = ref(isDevMode)
 const paramsLoaded = ref(false)
 
 const isSim = computed(() => platform.value === 'unity_sim')

--- a/composables/useDexiPlatform.ts
+++ b/composables/useDexiPlatform.ts
@@ -1,0 +1,57 @@
+import { ref, computed } from 'vue'
+import ROSLIB from 'roslib'
+
+export type DexiPlatform = 'ark_cm4' | 'cm5' | 'pi5' | 'unity_sim' | 'jetson' | 'unknown'
+
+const platform = ref<DexiPlatform>('unknown')
+const keyboardControlEnabled = ref(false)
+const paramsLoaded = ref(false)
+
+const isSim = computed(() => platform.value === 'unity_sim')
+const isHardware = computed(() => platform.value !== 'unknown' && !isSim.value)
+
+const queryParam = (ros: ROSLIB.Ros, name: string): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const param = new ROSLIB.Param({ ros, name })
+    param.get(
+      (value) => resolve(value),
+      (error) => reject(error)
+    )
+  })
+}
+
+const loadPlatformParams = async (ros: ROSLIB.Ros) => {
+  try {
+    const [platformValue, keyboardValue] = await Promise.allSettled([
+      queryParam(ros, '/rosbridge_websocket:dexi_platform'),
+      queryParam(ros, '/rosbridge_websocket:dexi_keyboard_control'),
+    ])
+
+    if (platformValue.status === 'fulfilled' && platformValue.value) {
+      platform.value = platformValue.value as DexiPlatform
+      console.log(`DEXI platform: ${platform.value}`)
+    }
+
+    if (keyboardValue.status === 'fulfilled') {
+      // Handle string 'true'/'false' from launch args as well as boolean
+      const val = keyboardValue.value
+      keyboardControlEnabled.value = val === true || val === 'true' || val === 'True'
+      console.log(`DEXI keyboard control: ${keyboardControlEnabled.value}`)
+    }
+  } catch (error) {
+    console.warn('Failed to load DEXI platform params:', error)
+  } finally {
+    paramsLoaded.value = true
+  }
+}
+
+export const useDexiPlatform = () => {
+  return {
+    platform,
+    keyboardControlEnabled,
+    paramsLoaded,
+    isSim,
+    isHardware,
+    loadPlatformParams,
+  }
+}

--- a/composables/useROS.ts
+++ b/composables/useROS.ts
@@ -1,5 +1,11 @@
 export const useROS = () => {
   const getROSURL = (): string => {
+    // Allow override via ?rosHost=192.168.68.60 query param (for local dev pointing at remote drone)
+    const params = new URLSearchParams(window.location.search)
+    const rosHost = params.get('rosHost')
+    if (rosHost) {
+      return `ws://${rosHost}:9090`
+    }
     const hostname = window.location.hostname
     const isSecure = window.location.protocol === 'https:'
     const protocol = isSecure ? 'wss:' : 'ws:'

--- a/pages/apriltag.vue
+++ b/pages/apriltag.vue
@@ -19,47 +19,45 @@
       </div>
     </div>
 
-    <!-- Main Content -->
+    <!-- Main Content — 2-column layout -->
     <div class="flex-1 overflow-y-auto p-4">
-      <div class="max-w-4xl mx-auto">
-        <!-- Info Banner -->
-        <div class="bg-blue-900/30 border border-blue-700 rounded-lg p-4 mb-4">
-          <h3 class="text-blue-400 font-semibold mb-2">How to Use</h3>
-          <ul class="text-sm text-gray-300 space-y-1">
-            <li>1. Ensure AprilTag is visible to the camera</li>
-            <li>2. Wait for the stability indicator to show <span class="text-green-400 font-semibold">STABLE</span></li>
-            <li>3. Position variance should be under 5 cm for reliable position hold</li>
-            <li>4. When ready, the banner will show <span class="text-green-400 font-semibold">READY FOR POSITION HOLD</span></li>
-          </ul>
-        </div>
+      <div class="max-w-7xl mx-auto">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <!-- Left column: Camera + Stability + Event Log -->
+          <div class="flex flex-col gap-3">
+            <!-- Camera Feed (compact) -->
+            <div class="bg-gray-800 rounded-lg p-3">
+              <h3 class="text-sm text-gray-400 uppercase mb-2">Camera Feed</h3>
+              <div class="relative bg-gray-900 rounded overflow-hidden" style="aspect-ratio: 4/3;">
+                <CameraFeed topic-name="/cam0/image_raw/compressed" />
+              </div>
+            </div>
 
-        <!-- Camera Feed -->
-        <div class="bg-gray-800 rounded-lg p-4 mb-4">
-          <h3 class="text-sm text-gray-400 uppercase mb-3">Camera Feed</h3>
-          <div class="relative aspect-video bg-gray-900 rounded overflow-hidden">
-            <CameraFeed topic-name="/cam0/image_raw/compressed" />
+            <!-- Stability handled inside AprilTagVisualizer below -->
+
+            <!-- Event Log -->
+            <div class="bg-gray-800 rounded-lg p-3">
+              <h3 class="text-sm text-gray-400 uppercase mb-2">Event Log</h3>
+              <div class="bg-gray-900 rounded p-2 h-24 overflow-y-auto font-mono text-xs">
+                <div
+                  v-for="(log, index) in logs"
+                  :key="index"
+                  class="mb-1 py-1 px-2 rounded"
+                  :class="logClass(log.type)"
+                >
+                  <span class="text-gray-500 mr-2">{{ log.time }}</span>
+                  {{ log.message }}
+                </div>
+                <div v-if="logs.length === 0" class="text-gray-500">
+                  Waiting for events...
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
 
-        <!-- AprilTag Visualizer Component -->
-        <AprilTagVisualizer :ros="ros" />
-
-        <!-- Event Log -->
-        <div class="bg-gray-800 rounded-lg p-4 mt-4">
-          <h3 class="text-sm text-gray-400 uppercase mb-3">Event Log</h3>
-          <div class="bg-gray-900 rounded p-3 h-40 overflow-y-auto font-mono text-xs">
-            <div
-              v-for="(log, index) in logs"
-              :key="index"
-              class="mb-1 py-1 px-2 rounded"
-              :class="logClass(log.type)"
-            >
-              <span class="text-gray-500 mr-2">{{ log.time }}</span>
-              {{ log.message }}
-            </div>
-            <div v-if="logs.length === 0" class="text-gray-500">
-              Waiting for events...
-            </div>
+          <!-- Right column: Visualizer data panels -->
+          <div>
+            <AprilTagVisualizer :ros="ros" />
           </div>
         </div>
       </div>

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -2,9 +2,11 @@
 import { ref, onMounted, onUnmounted } from "vue";
 import ROSLIB from "roslib";
 import { useROS } from "~/composables/useROS";
+import { useDexiPlatform } from "~/composables/useDexiPlatform";
 import type { DroneContext } from "~/composables/useChat";
 
 const { getROSURL } = useROS();
+const { isSim } = useDexiPlatform();
 
 const ros = ref<ROSLIB.Ros | null>(null);
 const rosConnected = ref(false);
@@ -123,15 +125,15 @@ const simulatorUrl = computed(() => {
       </div>
     </div>
 
-    <!-- Main content: Chat left, Simulator right -->
+    <!-- Main content: Chat left, Simulator right (sim only) -->
     <div class="flex-1 flex overflow-hidden">
       <!-- Chat panel -->
-      <div class="w-1/2 p-4 border-r border-base-content/10 overflow-hidden">
+      <div :class="isSim ? 'w-1/2' : 'w-full'" class="p-4 border-r border-base-content/10 overflow-hidden">
         <Chat :drone-context="droneContext" class="h-full" />
       </div>
 
-      <!-- Simulator panel -->
-      <div class="w-1/2 p-4 overflow-hidden">
+      <!-- Simulator panel (only in sim mode) -->
+      <div v-if="isSim" class="w-1/2 p-4 overflow-hidden">
         <iframe
           :src="simulatorUrl"
           class="w-full h-full rounded-lg border border-base-content/10"

--- a/pages/chat.vue
+++ b/pages/chat.vue
@@ -6,7 +6,7 @@ import { useDexiPlatform } from "~/composables/useDexiPlatform";
 import type { DroneContext } from "~/composables/useChat";
 
 const { getROSURL } = useROS();
-const { isSim } = useDexiPlatform();
+const { isSim, loadPlatformParams } = useDexiPlatform();
 
 const ros = ref<ROSLIB.Ros | null>(null);
 const rosConnected = ref(false);
@@ -20,6 +20,7 @@ const connectROS = () => {
   ros.value.on("connection", () => {
     rosConnected.value = true;
     subscribeToTopics();
+    loadPlatformParams(ros.value as ROSLIB.Ros);
   });
 
   ros.value.on("close", () => {

--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -7,6 +7,7 @@ import { AprilTag } from '~/assets/ts/apriltag';
 import { javascriptGenerator } from 'blockly/javascript';
 import ROSLIB from 'roslib';
 import { useROS } from '~/composables/useROS';
+import { useDexiPlatform } from '~/composables/useDexiPlatform';
 import { useTutorial } from '~/tutorial';
 import TutorialWelcome from '~/tutorial/components/TutorialWelcome.vue';
 import TutorialModal from '~/tutorial/components/TutorialModal.vue';
@@ -607,6 +608,7 @@ const options = {
 };
 
 const { getROSURL } = useROS();
+const { isSim, keyboardControlEnabled, loadPlatformParams } = useDexiPlatform();
 
 const connectToROS = () => {
   try {
@@ -691,6 +693,14 @@ const connectToROS = () => {
         nedDown.value = message.z;
         // Convert heading from radians to degrees (0-360)
         nedHeading.value = ((message.heading * 180 / Math.PI) + 360) % 360;
+      });
+
+      // Query platform params and auto-set view mode
+      loadPlatformParams(ros.value as ROSLIB.Ros).then(() => {
+        const autoMode = isSim.value ? 'simulator' : 'drone';
+        viewMode.value = autoMode;
+        localStorage.setItem('droneblocks_view_mode', autoMode);
+        console.log(`View mode auto-set to '${autoMode}' from platform param`);
       });
 
       console.log('✅ Connected to ROS and services initialized');
@@ -2093,7 +2103,7 @@ onUnmounted(() => {
                 <span>🏠</span>
                 <span>Dashboard</span>
               </a>
-              <button @click="openKeyboardControl" class="menu-item">
+              <button v-if="keyboardControlEnabled" @click="openKeyboardControl" class="menu-item">
                 <span>⌨️</span>
                 <span>Keyboard Control</span>
               </button>
@@ -2220,7 +2230,7 @@ onUnmounted(() => {
 
     <!-- Keyboard Control -->
     <KeyboardControl
-      v-if="ros && connected"
+      v-if="ros && connected && keyboardControlEnabled"
       :ros="ros"
       :isOpen="showKeyboardControl"
       @close="showKeyboardControl = false"

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -95,7 +95,8 @@ async function getNetworkInterfaces(): Promise<NetworkInterface[]> {
     if (dev === "lo" || dev.startsWith("veth")) continue;
 
     const operstate = await readProc(`/sys/class/net/${dev}/operstate`);
-    if (operstate !== "up") continue;
+    // USB cellular dongles (cdc_ether) report "unknown" operstate — treat as up
+    if (operstate !== "up" && operstate !== "unknown") continue;
 
     let type = "ethernet";
     try {

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -95,8 +95,7 @@ async function getNetworkInterfaces(): Promise<NetworkInterface[]> {
     if (dev === "lo" || dev.startsWith("veth")) continue;
 
     const operstate = await readProc(`/sys/class/net/${dev}/operstate`);
-    // USB cellular dongles (cdc_ether) report "unknown" operstate — treat as up
-    if (operstate !== "up" && operstate !== "unknown") continue;
+    if (operstate !== "up") continue;
 
     let type = "ethernet";
     try {


### PR DESCRIPTION
## Summary
- The chat page imported `isSim` from `useDexiPlatform()` but never called `loadPlatformParams()`, so the platform stayed as `unknown` and `isSim` was always `false`
- This caused the simulator iframe panel to never render, leaving chat full-width with no sim view
- Fix: call `loadPlatformParams(ros)` on ROS connection in `chat.vue`, matching what `droneblocks.vue` already does

## Test plan
- [ ] Open `http://localhost/chat` with the sim stack running
- [ ] Verify the page shows split view: chat on left, Unity sim iframe on right
- [ ] Verify connecting to a physical DEXI (non-sim) still shows chat full-width