### PR TITLE
Allow Unity sim URL override via NUXT_PUBLIC_SIM_URL

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,9 @@ export default defineNuxtConfig({
     // Server-side only (not exposed to client)
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     chatLogUrl: process.env.CHAT_LOG_URL,
+    public: {
+      simUrl: process.env.NUXT_PUBLIC_SIM_URL || ''
+    }
   },
   postcss: {
     plugins: {

--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -125,7 +125,7 @@ const unityUrl = ref('');
 if (process.client) {
   const hostname = window.location.hostname;
   const port = window.location.port;
-  unityUrl.value = `http://${hostname}:1337`;
+  unityUrl.value = useRuntimeConfig().public.simUrl || `http://${hostname}:1337`;
   scanPageUrl.value = `${window.location.protocol}//${hostname}${port ? ':' + port : ''}/scan`;
 }
 

--- a/pages/gamepad.vue
+++ b/pages/gamepad.vue
@@ -237,7 +237,7 @@ const unityUrl = ref('')
 if (process.client) {
   const hostname = window.location.hostname
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:'
-  unityUrl.value = `${protocol}//${hostname}:1337`
+  unityUrl.value = useRuntimeConfig().public.simUrl || `${protocol}//${hostname}:1337`
 }
 
 // Split panel state

--- a/pages/webcam.vue
+++ b/pages/webcam.vue
@@ -159,7 +159,7 @@ if (process.client) {
     // Fallback to current hostname with matching protocol
     const hostname = window.location.hostname
     const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:'
-    unityUrl.value = `${protocol}//${hostname}:1337`
+    unityUrl.value = useRuntimeConfig().public.simUrl || `${protocol}//${hostname}:1337`
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `runtimeConfig.public.simUrl` sourced from `NUXT_PUBLIC_SIM_URL` env var.
- Updates `pages/droneblocks.vue`, `pages/gamepad.vue`, and `pages/webcam.vue` to use that URL for the Unity iframe when set, falling back to the existing `http://hostname:1337` behavior when unset.
- Unblocks the dexi-sim-provisioner switch from random `*.trycloudflare.com` quick-tunnel URLs to branded `*.dexisim.io` named-tunnel URLs, which need Unity served at a sibling subdomain (since the GCS host won't expose port 1337 over the tunnel).

## Hardware safety
- Hardware container does not set `NUXT_PUBLIC_SIM_URL` → `simUrl` is `''` → fallback to `${hostname}:1337` → identical to current behavior.
- Same image, same git branch, same defaults — env var is the only switch.
- Image will be re-pushed as `:0.20` only (not `:latest`) until sim has been verified end-to-end on a deployed instance.

## Test plan
- [ ] Build image without `NUXT_PUBLIC_SIM_URL`, deploy to a Pi, confirm GCS loads identically at http://192.168.4.1 (Unity iframe behavior unchanged)
- [ ] Build image with `NUXT_PUBLIC_SIM_URL=https://sim-test.example.com`, run locally, confirm Unity iframe loads from that URL
- [ ] Verify both `droneblocks.vue` and `gamepad.vue` pages pick up the override
- [ ] Verify `webcam.vue` still prefers the `?unityUrl=` query param when present, falls through to env override when not, and falls through to `:1337` when neither is set