### PR TITLE
Allow rosbridge URL override via NUXT_PUBLIC_ROSBRIDGE_URL

### DIFF
--- a/composables/useROS.ts
+++ b/composables/useROS.ts
@@ -6,11 +6,16 @@ export const useROS = () => {
     if (rosHost) {
       return `ws://${rosHost}:9090`
     }
+    // Branded tunnel deployments inject NUXT_PUBLIC_ROSBRIDGE_URL pointing at
+    // a dedicated rosbridge subdomain. Use it when set; fall back to legacy
+    // same-host logic for hardware (raw IP) and local dev.
+    const configured = useRuntimeConfig().public.rosbridgeUrl
+    if (configured) {
+      return configured
+    }
     const hostname = window.location.hostname
     const isSecure = window.location.protocol === 'https:'
     const protocol = isSecure ? 'wss:' : 'ws:'
-    // Over HTTPS (e.g. Cloudflare tunnel), route through nginx reverse proxy
-    // Over HTTP (local network), connect directly to rosbridge port
     const target = isSecure ? '/rosbridge' : ':9090'
     return `${protocol}//${hostname}${target}`
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,7 +7,8 @@ export default defineNuxtConfig({
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     chatLogUrl: process.env.CHAT_LOG_URL,
     public: {
-      simUrl: process.env.NUXT_PUBLIC_SIM_URL || ''
+      simUrl: process.env.NUXT_PUBLIC_SIM_URL || '',
+      rosbridgeUrl: process.env.NUXT_PUBLIC_ROSBRIDGE_URL || ''
     }
   },
   postcss: {


### PR DESCRIPTION
## Summary

Adds `runtimeConfig.public.rosbridgeUrl` sourced from `NUXT_PUBLIC_ROSBRIDGE_URL`. `useROS.ts` prefers it when set, falls back to existing same-host logic when unset.

## Why

PR #28 + the dexi-sim-provisioner branded-URL migration assumed `wss://hostname/rosbridge` would work over Cloudflare tunnels (with cloudflared path-routing the WS upgrade to port 9090). It doesn't — cloudflared forwards the path verbatim, and rosbridge_server only accepts upgrades at root (`/`), not `/rosbridge`. Symptom: GCS shows "ROS connection closed" / "Flight Mode Unknown" / N/A telemetry on tunneled deployments.

Fix: route rosbridge through a dedicated subdomain (handled in dexi-sim-provisioner) and have the GCS use the injected URL directly. The provisioner-side change to add the subdomain ships separately.

## Hardware safety
- Hardware container does not set `NUXT_PUBLIC_ROSBRIDGE_URL` → `rosbridgeUrl` is `''` → falls through to existing `wss://hostname/rosbridge` (HTTPS) or `ws://hostname:9090` (HTTP) logic → identical to current behavior.
- Same image, same git branch — env var is the only switch.
- Will be re-pushed as `:0.20` only (not `:latest`) until sim is verified end-to-end.

## Test plan
- [ ] Build image without `NUXT_PUBLIC_ROSBRIDGE_URL`, deploy to a Pi, confirm GCS connects to rosbridge unchanged at http://192.168.4.1
- [ ] Build image with `NUXT_PUBLIC_ROSBRIDGE_URL=wss://ros-test.example.com`, run locally, confirm `useROS.getROSURL()` returns that URL exactly
- [ ] After provisioner companion PR ships, provision a fresh sim and verify ROS telemetry appears in GCS