### PR TITLE
Allow Node-RED URL override via NUXT_PUBLIC_NODE_RED_URL

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,8 @@ export default defineNuxtConfig({
     chatLogUrl: process.env.CHAT_LOG_URL,
     public: {
       simUrl: process.env.NUXT_PUBLIC_SIM_URL || '',
-      rosbridgeUrl: process.env.NUXT_PUBLIC_ROSBRIDGE_URL || ''
+      rosbridgeUrl: process.env.NUXT_PUBLIC_ROSBRIDGE_URL || '',
+      nodeRedUrl: process.env.NUXT_PUBLIC_NODE_RED_URL || ''
     }
   },
   postcss: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -73,7 +73,7 @@
 
         <!-- Node-RED -->
         <NuxtLink
-          :to="`http://${hostname}:1880`"
+          :to="nodeRedUrl"
           target="_blank"
           class="group card"
         >
@@ -217,6 +217,7 @@
 
 <script setup>
 const hostname = process.client ? window.location.hostname : '192.168.4.1'
+const nodeRedUrl = useRuntimeConfig().public.nodeRedUrl || `http://${hostname}:1880`
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Mirrors PR #28 (sim URL) and #29 (rosbridge URL): adds `nodeRedUrl` to `runtimeConfig.public` and updates the Node-RED card on `pages/index.vue` to use it with the existing `http://${hostname}:1880` fallback.

## Why

Branded sim deployments now expose Node-RED at a dedicated subdomain (`nodered-{base}.dexisim.io`). The GCS card needs to know that URL because Cloudflare's free proxy doesn't forward port 1880 on the main hostname.

## Hardware safety
- Hardware container does not set `NUXT_PUBLIC_NODE_RED_URL` → empty string → falls through to `http://{hostname}:1880` → identical to today.
- Same image, same code, env var is the only switch.
- Will be re-pushed as `:0.20` after merge (held off `:latest` until sim is verified end-to-end).

## Test plan
- [ ] Hardware: confirm Node-RED card still opens `http://192.168.4.1:1880` unchanged
- [ ] Local docker: confirm card opens `http://localhost:1880` unchanged
- [ ] Cloud sim (after companion provisioner PR): card opens `https://nodered-{base}.dexisim.io`