### PR TITLE
Pass rosbridge URL to Unity iframe via query param

### DIFF
--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -120,12 +120,20 @@ const nedEast = ref<number>(0);
 const nedDown = ref<number>(0);
 const nedHeading = ref<number>(0);
 
-// Unity simulator URL - use current hostname
+// Unity simulator URL - use current hostname.
+// Append ?rosbridge=... so the Unity WebGL build connects to the right
+// rosbridge endpoint via its query-param Priority 1 path
+// (Assets/Plugins/WebGL/RosBridgeUrlHelper.jslib in the Unity project).
+// Without this, Unity falls back to constructing wss://{iframe-hostname}:9090,
+// which fails on tunneled deployments because Cloudflare doesn't proxy 9090
+// on the sim-* subdomain.
 const unityUrl = ref('');
 if (process.client) {
   const hostname = window.location.hostname;
   const port = window.location.port;
-  unityUrl.value = useRuntimeConfig().public.simUrl || `http://${hostname}:1337`;
+  const baseSimUrl = useRuntimeConfig().public.simUrl || `http://${hostname}:1337`;
+  const rosbridgeUrl = useRuntimeConfig().public.rosbridgeUrl || `ws://${hostname}:9090`;
+  unityUrl.value = `${baseSimUrl}?rosbridge=${encodeURIComponent(rosbridgeUrl)}`;
   scanPageUrl.value = `${window.location.protocol}//${hostname}${port ? ':' + port : ''}/scan`;
 }
 

--- a/pages/gamepad.vue
+++ b/pages/gamepad.vue
@@ -232,12 +232,17 @@ import { useROS } from '~/composables/useROS'
 
 const { getROSURL } = useROS()
 
-// Unity URL
+// Unity URL — append ?rosbridge=... so Unity's WebGL build connects to the
+// right rosbridge endpoint (Priority 1 in Unity's RosBridgeUrlHelper.jslib).
+// Without this, Unity falls back to wss://{iframe-hostname}:9090 which fails
+// on tunneled deployments.
 const unityUrl = ref('')
 if (process.client) {
   const hostname = window.location.hostname
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:'
-  unityUrl.value = useRuntimeConfig().public.simUrl || `${protocol}//${hostname}:1337`
+  const baseSimUrl = useRuntimeConfig().public.simUrl || `${protocol}//${hostname}:1337`
+  const rosbridgeUrl = useRuntimeConfig().public.rosbridgeUrl || `ws://${hostname}:9090`
+  unityUrl.value = `${baseSimUrl}?rosbridge=${encodeURIComponent(rosbridgeUrl)}`
 }
 
 // Split panel state


### PR DESCRIPTION
## Summary

Append `?rosbridge=...` to the Unity iframe `src` on `pages/droneblocks.vue` and `pages/gamepad.vue` so the WebGL build connects to the right rosbridge endpoint on tunneled deployments. `pages/webcam.vue` already does this — this brings the other two pages in line.

## Why

Unity's `ROSBridgeManager.cs` (in the [DEXI Drone Simulator](../) project) has a 3-tier priority chain in `GetRosBridgeUrl()`:

1. `?rosbridge=` URL query param
2. Construct from `window.location.hostname` + port 9090
3. Hardcoded fallback `ws://localhost:9090`

On tunneled cloud deployments the iframe loads at `sim-{base}.dexisim.io` with no query param, so Unity falls to Priority 2 and constructs `wss://sim-{base}.dexisim.io:9090`. **Cloudflare's free proxy doesn't forward port 9090 on the sim subdomain**, so the connection silently fails. Symptom: simulated drone's LED ring stuck on default green; no telemetry from Unity reaching the GCS.

User-confirmed by manually appending the query param to the iframe URL — LED started animating.

## Hardware safety

- Unity isn't part of hardware deployments — only the GCS image runs on the Pi.
- Local docker: with no `NUXT_PUBLIC_*_URL` set, the query param resolves to `?rosbridge=ws://localhost:9090`, which matches what Unity would have constructed via Priority 2 anyway. No behavior change.

## Test plan

- [ ] On a tunneled sim, open the GCS, navigate to `/droneblocks`, click LED color buttons → Unity drone's LED ring changes
- [ ] Same on `/gamepad`
- [ ] Local `docker compose up`: GCS → /droneblocks → LED still works (control case)