### PR TITLE
Allow code-server URL override via NUXT_PUBLIC_VSCODE_URL

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,8 @@ export default defineNuxtConfig({
     public: {
       simUrl: process.env.NUXT_PUBLIC_SIM_URL || '',
       rosbridgeUrl: process.env.NUXT_PUBLIC_ROSBRIDGE_URL || '',
-      nodeRedUrl: process.env.NUXT_PUBLIC_NODE_RED_URL || ''
+      nodeRedUrl: process.env.NUXT_PUBLIC_NODE_RED_URL || '',
+      vscodeUrl: process.env.NUXT_PUBLIC_VSCODE_URL || ''
     }
   },
   postcss: {

--- a/pages/demos.vue
+++ b/pages/demos.vue
@@ -213,8 +213,11 @@ function launchDemo(demo: Demo) {
 }
 
 function launchPythonMission(mission: PythonMission) {
-  // Open code-server in a new tab with the folder and file
-  const url = `http://${hostname}:9999/?folder=${encodeURIComponent(mission.folder)}&file=${encodeURIComponent(mission.file)}`;
+  // Open code-server in a new tab with the folder and file. Branded
+  // tunnel deployments inject NUXT_PUBLIC_VSCODE_URL; hardware/local dev
+  // fall back to http://hostname:9999.
+  const baseUrl = useRuntimeConfig().public.vscodeUrl || `http://${hostname}:9999`;
+  const url = `${baseUrl}/?folder=${encodeURIComponent(mission.folder)}&file=${encodeURIComponent(mission.file)}`;
   window.open(url, '_blank');
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -91,7 +91,7 @@
 
         <!-- VS Code Server -->
         <NuxtLink
-          :to="`http://${hostname}:9999`"
+          :to="vscodeUrl"
           target="_blank"
           class="group card"
         >
@@ -218,6 +218,7 @@
 <script setup>
 const hostname = process.client ? window.location.hostname : '192.168.4.1'
 const nodeRedUrl = useRuntimeConfig().public.nodeRedUrl || `http://${hostname}:1880`
+const vscodeUrl = useRuntimeConfig().public.vscodeUrl || `http://${hostname}:9999`
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Adds `vscodeUrl` to `runtimeConfig.public`, sourced from `NUXT_PUBLIC_VSCODE_URL`. Two GCS pages updated to use it with the existing `http://${hostname}:9999` fallback:

- `pages/index.vue` — VS Code Server card on the home page
- `pages/demos.vue` — `launchPythonMission()` opens code-server with `?folder=...&file=...` query params

## Why

Pairs with [dexi-sim-provisioner PR #15](https://github.com/DroneBlocks/dexi-sim-provisioner/pull/15) which tunnels port 9999 as a `code-{base}.dexisim.io` subdomain. Without this PR, the GCS still tries `http://${hostname}:9999` over the tunnel and gets nothing (Cloudflare doesn't pass that port).

## Hardware / local safety
- Hardware container does not set `NUXT_PUBLIC_VSCODE_URL` → empty → falls through to existing `${hostname}:9999` behavior.
- Local docker: same fallback.
- Will be re-pushed as `:0.20` only (not `:latest`) until verified end-to-end on cloud sim.

## Test plan

- [ ] Hardware: VS Code card still opens `http://192.168.4.1:9999` unchanged
- [ ] Local docker: card still opens `http://localhost:9999` unchanged
- [ ] Cloud sim (after companion provisioner PR): card opens `https://code-{base}.dexisim.io`; Python demo open works with folder/file params preserved