### PR TITLE
feat(status): add CPU Load + break CPU into its own card

### DIFF
--- a/pages/status.vue
+++ b/pages/status.vue
@@ -90,6 +90,27 @@
                   />
                 </div>
               </div>
+              <div v-if="status!.cpuPerCore?.length" class="mt-3 space-y-1.5">
+                <div
+                  v-for="(pct, i) in status!.cpuPerCore"
+                  :key="i"
+                  class="flex items-center gap-2 text-xs"
+                >
+                  <span class="text-slate-400 font-mono w-9">cpu{{ i }}</span>
+                  <div class="flex-1 bg-slate-200 rounded h-1.5">
+                    <div
+                      class="h-1.5 rounded transition-all duration-500"
+                      :class="{
+                        'bg-green-500': pct < 70,
+                        'bg-amber-500': pct >= 70 && pct < 90,
+                        'bg-red-500': pct >= 90
+                      }"
+                      :style="{ width: pct + '%' }"
+                    />
+                  </div>
+                  <span class="text-slate-500 font-mono w-9 text-right">{{ Math.round(pct) }}%</span>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -322,6 +343,7 @@ interface SystemStatus {
   memory: { totalMb: number; usedMb: number; freeMb: number } | null;
   cpuTempC: number | null;
   cpuUsagePct: number | null;
+  cpuPerCore: number[] | null;
   interfaces: NetworkInterface[];
   savedConnections: SavedConnection[];
   wifiMode: "hotspot" | "client" | "disconnected";

--- a/pages/status.vue
+++ b/pages/status.vue
@@ -188,23 +188,47 @@
 
         <!-- WiFi Mode Section -->
         <div class="status-card mb-6">
-          <div class="flex items-center justify-between mb-4">
-            <h2 class="status-card-title mb-0">WiFi Mode</h2>
-            <div class="flex items-center bg-slate-100 rounded-lg p-1">
+          <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+            <div class="flex items-center gap-3">
+              <h2 class="status-card-title mb-0">WiFi Mode</h2>
+              <span
+                class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium"
+                :class="{
+                  'bg-amber-100 text-amber-800': status!.wifiMode === 'hotspot',
+                  'bg-blue-100 text-blue-800': status!.wifiMode === 'client',
+                  'bg-slate-200 text-slate-600': status!.wifiMode === 'disconnected'
+                }"
+              >
+                <span class="inline-block w-1.5 h-1.5 rounded-full"
+                  :class="{
+                    'bg-amber-500': status!.wifiMode === 'hotspot',
+                    'bg-blue-500': status!.wifiMode === 'client',
+                    'bg-slate-400': status!.wifiMode === 'disconnected'
+                  }"
+                />
+                Current:
+                {{
+                  status!.wifiMode === 'hotspot' ? 'Hotspot'
+                  : status!.wifiMode === 'client' ? 'Client'
+                  : 'Disconnected'
+                }}
+              </span>
+            </div>
+            <div class="flex items-center gap-2">
               <button
-                class="mode-btn"
-                :class="status!.wifiMode === 'hotspot' ? 'mode-btn-active' : ''"
+                v-if="status!.wifiMode !== 'hotspot'"
+                class="btn btn-sm btn-outline btn-warning"
                 :disabled="switching"
                 @click="switchToHotspot"
               >
-                Hotspot
+                📡 Switch to Hotspot
               </button>
               <button
-                class="mode-btn"
-                :class="status!.wifiMode === 'client' ? 'mode-btn-active' : ''"
-                :disabled="switching || !hasClientNetworks"
+                v-if="status!.wifiMode !== 'client' && hasClientNetworks"
+                class="btn btn-sm btn-outline btn-info"
+                :disabled="switching"
               >
-                Client
+                📶 Switch to Client
               </button>
             </div>
           </div>

--- a/pages/status.vue
+++ b/pages/status.vue
@@ -45,9 +45,9 @@
                 <span class="status-label">Hostname</span>
                 <span class="status-value font-mono">{{ status!.hostname }}</span>
               </div>
-              <div v-if="status!.model" class="status-row">
+              <div v-if="status!.model" class="flex flex-col gap-1">
                 <span class="status-label">Model</span>
-                <span class="status-value font-mono text-xs">{{ status!.model }}</span>
+                <span class="status-value font-mono text-xs break-words leading-snug">{{ status!.model }}</span>
               </div>
               <div class="status-row">
                 <span class="status-label">Uptime</span>

--- a/pages/status.vue
+++ b/pages/status.vue
@@ -143,26 +143,45 @@
             </div>
           </div>
 
-          <!-- 5G / Cellular -->
-          <div class="status-card">
-            <h2 class="status-card-title">Cellular</h2>
-            <div v-if="cellularInterface" class="space-y-3">
-              <div class="flex items-center gap-2 mb-1">
-                <span class="inline-block w-2 h-2 rounded-full bg-green-500" />
-                <span class="text-sm text-green-700 font-medium">Connected</span>
-              </div>
-              <div class="status-row">
-                <span class="status-label">Interface</span>
-                <span class="status-value font-mono">{{ cellularInterface.name }}</span>
-              </div>
-              <div v-if="cellularInterface.ip" class="status-row">
-                <span class="status-label">IP</span>
-                <span class="status-value font-mono">{{ cellularInterface.ip }}</span>
+          <!-- Top Processes -->
+          <div v-if="status!.topProcesses?.length" class="status-card">
+            <h2 class="status-card-title">Top Processes</h2>
+            <div class="space-y-1.5">
+              <div
+                v-for="p in status!.topProcesses"
+                :key="p.pid"
+                class="flex items-center gap-2 text-xs"
+              >
+                <span
+                  class="font-mono w-12 text-right"
+                  :class="{
+                    'text-red-600': p.cpuPct >= 50,
+                    'text-amber-600': p.cpuPct >= 20 && p.cpuPct < 50,
+                    'text-slate-700': p.cpuPct < 20
+                  }"
+                >{{ p.cpuPct.toFixed(1) }}%</span>
+                <span class="font-mono truncate flex-1" :title="p.command">{{ p.command }}</span>
+                <span class="font-mono text-slate-400 w-12 text-right text-[10px]">{{ p.pid }}</span>
               </div>
             </div>
-            <div v-else class="flex items-center gap-2">
-              <span class="inline-block w-2 h-2 rounded-full bg-slate-300" />
-              <span class="text-sm text-slate-400">No modem detected</span>
+          </div>
+        </div>
+
+        <!-- Cellular (only when a modem is present) -->
+        <div v-if="cellularInterface" class="status-card mb-6">
+          <h2 class="status-card-title">Cellular</h2>
+          <div class="space-y-3">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="inline-block w-2 h-2 rounded-full bg-green-500" />
+              <span class="text-sm text-green-700 font-medium">Connected</span>
+            </div>
+            <div class="status-row">
+              <span class="status-label">Interface</span>
+              <span class="status-value font-mono">{{ cellularInterface.name }}</span>
+            </div>
+            <div v-if="cellularInterface.ip" class="status-row">
+              <span class="status-label">IP</span>
+              <span class="status-value font-mono">{{ cellularInterface.ip }}</span>
             </div>
           </div>
         </div>
@@ -344,6 +363,7 @@ interface SystemStatus {
   cpuTempC: number | null;
   cpuUsagePct: number | null;
   cpuPerCore: number[] | null;
+  topProcesses: { pid: number; cpuPct: number; command: string }[] | null;
   interfaces: NetworkInterface[];
   savedConnections: SavedConnection[];
   wifiMode: "hotspot" | "client" | "disconnected";

--- a/pages/status.vue
+++ b/pages/status.vue
@@ -34,8 +34,8 @@
       </div>
 
       <template v-else>
-        <!-- Top row: System + Memory -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+        <!-- Top row: System + CPU + Memory + Cellular -->
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 mb-6">
 
           <!-- System -->
           <div class="status-card">
@@ -53,8 +53,15 @@
                 <span class="status-label">Uptime</span>
                 <span class="status-value">{{ status!.uptime || 'N/A' }}</span>
               </div>
+            </div>
+          </div>
+
+          <!-- CPU -->
+          <div class="status-card">
+            <h2 class="status-card-title">CPU</h2>
+            <div class="space-y-3">
               <div v-if="status!.cpuTempC != null" class="status-row">
-                <span class="status-label">CPU Temp</span>
+                <span class="status-label">Temperature</span>
                 <span
                   class="status-value"
                   :class="{
@@ -65,6 +72,23 @@
                 >
                   {{ status!.cpuTempC!.toFixed(1) }} °C
                 </span>
+              </div>
+              <div v-if="status!.cpuUsagePct != null" class="status-row">
+                <span class="status-label">Load</span>
+                <span class="status-value">{{ cpuPercent }}%</span>
+              </div>
+              <div v-if="status!.cpuUsagePct != null" class="mt-3">
+                <div class="w-full bg-slate-200 rounded-full h-2">
+                  <div
+                    class="h-2 rounded-full transition-all duration-500"
+                    :class="{
+                      'bg-green-500': cpuPercent < 70,
+                      'bg-amber-500': cpuPercent >= 70 && cpuPercent < 90,
+                      'bg-red-500': cpuPercent >= 90
+                    }"
+                    :style="{ width: cpuPercent + '%' }"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -297,6 +321,7 @@ interface SystemStatus {
   uptime: string;
   memory: { totalMb: number; usedMb: number; freeMb: number } | null;
   cpuTempC: number | null;
+  cpuUsagePct: number | null;
   interfaces: NetworkInterface[];
   savedConnections: SavedConnection[];
   wifiMode: "hotspot" | "client" | "disconnected";
@@ -315,6 +340,11 @@ const memPercent = computed(() => {
   return Math.round(
     (status.value.memory.usedMb / status.value.memory.totalMb) * 100
   );
+});
+
+const cpuPercent = computed(() => {
+  const v = status.value?.cpuUsagePct;
+  return v == null ? 0 : Math.round(v);
 });
 
 const wifiInterface = computed(() =>

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -160,25 +160,44 @@ async function getSavedConnections(): Promise<SavedConnection[]> {
   return connections;
 }
 
-// /proc/stat aggregate CPU usage. Reads twice with a short delay and computes
-// the idle-time delta ratio. Same sampling pattern as `top` / `vmstat`.
-async function getCpuUsagePct(): Promise<number | null> {
+// /proc/stat CPU usage — aggregate + per-core. Reads twice with a short delay
+// and computes the idle-time delta ratio per cpu line. First "cpu " line is
+// aggregate; "cpu0..cpuN" follow. Same sampling pattern as `top` / `vmstat`.
+interface CpuStats {
+  aggregate: number | null;
+  perCore: number[] | null;
+}
+async function getCpuStats(): Promise<CpuStats> {
   const read = async () => {
-    const raw = (await readFile("/proc/stat", "utf-8")).split("\n")[0];
-    const fields = raw.split(/\s+/).slice(1).map(Number);
-    const total = fields.reduce((a, b) => a + b, 0);
-    const idle = fields[3] + (fields[4] || 0); // idle + iowait
-    return { total, idle };
+    const lines = (await readFile("/proc/stat", "utf-8"))
+      .split("\n")
+      .filter((l) => l.startsWith("cpu"));
+    return lines.map((l) => {
+      const fields = l.split(/\s+/).slice(1).map(Number);
+      const total = fields.reduce((a, b) => a + b, 0);
+      const idle = fields[3] + (fields[4] || 0); // idle + iowait
+      return { total, idle };
+    });
+  };
+  const usagePct = (
+    before: { total: number; idle: number },
+    after: { total: number; idle: number }
+  ) => {
+    const dTotal = after.total - before.total;
+    const dIdle = after.idle - before.idle;
+    return dTotal > 0 ? Math.max(0, Math.min(100, 100 * (1 - dIdle / dTotal))) : 0;
   };
   try {
     const a = await read();
     await new Promise((r) => setTimeout(r, 100));
     const b = await read();
-    const dTotal = b.total - a.total;
-    const dIdle = b.idle - a.idle;
-    return dTotal > 0 ? Math.max(0, Math.min(100, 100 * (1 - dIdle / dTotal))) : null;
+    if (a.length === 0 || a.length !== b.length) return { aggregate: null, perCore: null };
+    return {
+      aggregate: usagePct(a[0], b[0]),
+      perCore: a.slice(1).map((ac, i) => usagePct(ac, b[i + 1])),
+    };
   } catch {
-    return null;
+    return { aggregate: null, perCore: null };
   }
 }
 
@@ -194,7 +213,7 @@ async function getWifiMode(): Promise<"hotspot" | "client" | "disconnected"> {
 }
 
 export default defineEventHandler(async () => {
-  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode, cpuUsagePct] =
+  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode, cpu] =
     await Promise.all([
       run("hostname"),
       readProc("/proc/uptime"),
@@ -204,7 +223,7 @@ export default defineEventHandler(async () => {
       getNetworkInterfaces(),
       getSavedConnections(),
       getWifiMode(),
-      getCpuUsagePct(),
+      getCpuStats(),
     ]);
 
   // Parse uptime from seconds
@@ -230,7 +249,8 @@ export default defineEventHandler(async () => {
     uptime,
     memory,
     cpuTempC,
-    cpuUsagePct,
+    cpuUsagePct: cpu.aggregate,
+    cpuPerCore: cpu.perCore,
     interfaces,
     savedConnections,
     wifiMode,

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -201,6 +201,38 @@ async function getCpuStats(): Promise<CpuStats> {
   }
 }
 
+// Top N processes by CPU% — uses `top -bn2 -d 0.5`, second iteration gives a
+// real sample window (first iteration's %CPU is cumulative-since-start, useless).
+interface TopProcess { pid: number; cpuPct: number; command: string }
+async function getTopProcesses(limit = 5): Promise<TopProcess[] | null> {
+  const raw = await run("top -bn2 -d 0.5 -w512 -o %CPU 2>/dev/null");
+  if (!raw) return null;
+  // Find the SECOND "PID  USER ..." header — its block is the real sample.
+  const lines = raw.split("\n");
+  let pidHdrCount = 0;
+  let bodyStart = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*PID\s+USER/.test(lines[i])) {
+      pidHdrCount++;
+      if (pidHdrCount === 2) { bodyStart = i + 1; break; }
+    }
+  }
+  if (bodyStart < 0) return null;
+  const out: TopProcess[] = [];
+  for (let i = bodyStart; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) break;
+    const parts = line.split(/\s+/);
+    if (parts.length < 12) continue;
+    const pid = Number(parts[0]);
+    const cpuPct = Number(parts[8]); // %CPU column in `top` BATCH output
+    if (!Number.isFinite(pid) || !Number.isFinite(cpuPct)) continue;
+    if (cpuPct < 0.1) continue;
+    out.push({ pid, cpuPct, command: parts.slice(11).join(" ") });
+  }
+  return out.sort((a, b) => b.cpuPct - a.cpuPct).slice(0, limit);
+}
+
 async function getWifiMode(): Promise<"hotspot" | "client" | "disconnected"> {
   const activeRaw = await run(
     "nmcli -t -f NAME,TYPE connection show --active 2>/dev/null"
@@ -213,7 +245,7 @@ async function getWifiMode(): Promise<"hotspot" | "client" | "disconnected"> {
 }
 
 export default defineEventHandler(async () => {
-  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode, cpu] =
+  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode, cpu, topProcesses] =
     await Promise.all([
       run("hostname"),
       readProc("/proc/uptime"),
@@ -224,6 +256,7 @@ export default defineEventHandler(async () => {
       getSavedConnections(),
       getWifiMode(),
       getCpuStats(),
+      getTopProcesses(5),
     ]);
 
   // Parse uptime from seconds
@@ -251,6 +284,7 @@ export default defineEventHandler(async () => {
     cpuTempC,
     cpuUsagePct: cpu.aggregate,
     cpuPerCore: cpu.perCore,
+    topProcesses,
     interfaces,
     savedConnections,
     wifiMode,

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -160,6 +160,28 @@ async function getSavedConnections(): Promise<SavedConnection[]> {
   return connections;
 }
 
+// /proc/stat aggregate CPU usage. Reads twice with a short delay and computes
+// the idle-time delta ratio. Same sampling pattern as `top` / `vmstat`.
+async function getCpuUsagePct(): Promise<number | null> {
+  const read = async () => {
+    const raw = (await readFile("/proc/stat", "utf-8")).split("\n")[0];
+    const fields = raw.split(/\s+/).slice(1).map(Number);
+    const total = fields.reduce((a, b) => a + b, 0);
+    const idle = fields[3] + (fields[4] || 0); // idle + iowait
+    return { total, idle };
+  };
+  try {
+    const a = await read();
+    await new Promise((r) => setTimeout(r, 100));
+    const b = await read();
+    const dTotal = b.total - a.total;
+    const dIdle = b.idle - a.idle;
+    return dTotal > 0 ? Math.max(0, Math.min(100, 100 * (1 - dIdle / dTotal))) : null;
+  } catch {
+    return null;
+  }
+}
+
 async function getWifiMode(): Promise<"hotspot" | "client" | "disconnected"> {
   const activeRaw = await run(
     "nmcli -t -f NAME,TYPE connection show --active 2>/dev/null"
@@ -172,7 +194,7 @@ async function getWifiMode(): Promise<"hotspot" | "client" | "disconnected"> {
 }
 
 export default defineEventHandler(async () => {
-  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode] =
+  const [hostname, uptimeRaw, memRaw, tempRaw, model, interfaces, savedConnections, wifiMode, cpuUsagePct] =
     await Promise.all([
       run("hostname"),
       readProc("/proc/uptime"),
@@ -182,6 +204,7 @@ export default defineEventHandler(async () => {
       getNetworkInterfaces(),
       getSavedConnections(),
       getWifiMode(),
+      getCpuUsagePct(),
     ]);
 
   // Parse uptime from seconds
@@ -207,6 +230,7 @@ export default defineEventHandler(async () => {
     uptime,
     memory,
     cpuTempC,
+    cpuUsagePct,
     interfaces,
     savedConnections,
     wifiMode,


### PR DESCRIPTION
## Summary

The System card was carrying hostname, model, uptime, and CPU temp all in one place. Splitting CPU into its own card opens room for a new **CPU Load** stat (progress-bar styled like Memory) without losing density anywhere else.

## What changed

**Server** (`server/api/system-status.get.ts`)
- New `getCpuUsagePct()` helper — reads `/proc/stat` twice with a 100 ms gap and computes the idle-time delta ratio (same sampling pattern as `top`/`vmstat`). Returns `null` if the read fails.
- Added to the existing parallel `Promise.all` gather; surfaced as `cpuUsagePct` in the response.
- 100 ms sampling delay is negligible against the 5 s page poll interval.

**UI** (`pages/status.vue`)
- Top grid widened from `lg:grid-cols-3` to `xl:grid-cols-4`. At `md` it's 2 columns (System+CPU, Memory+Cellular) so it remains usable on narrower screens.
- New **CPU card** with **Temperature** (kept the same green/amber/red thresholds: <60 / <75 / ≥75 °C) and **Load** with a progress bar mirroring Memory's style.
- Removed CPU Temp row from the System card.

## Live-verified on the bench

The API change was patched into a running container at 192.168.4.30 first; the new field is live:

\`\`\`
curl http://localhost/api/system-status →
  "cpuTempC": 36.95,
  "cpuUsagePct": 20.51
\`\`\`

This PR is the source-side complement so the change persists across image redeploys.

## Test plan
- [ ] \`/status\` renders 4 cards on wide screens, 2x2 on medium, stacked on narrow.
- [ ] CPU card shows current Temp + Load with bar; values update every 5 s.
- [ ] System card no longer has CPU Temp row.
- [ ] CPU Load row hides gracefully if \`/proc/stat\` returns null.