### PR TITLE
feat(readiness-strip): persistent telemetry header on every page (closes #35)

### DIFF
--- a/components/Pill.vue
+++ b/components/Pill.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+// Reusable status pill for ReadinessStrip + future status panels.
+// `label` is the static prefix ("FC", "Battery"); `value` is the live string.
+// `state` controls color: green / amber / red / gray.
+
+defineProps<{
+  label?: string
+  value: string
+  state: 'green' | 'amber' | 'red' | 'gray'
+}>()
+</script>
+
+<template>
+  <span class="pill" :class="`pill-${state}`">
+    <span class="dot" />
+    <span v-if="label" class="pill-label">{{ label }}</span>
+    <span class="pill-value">{{ value }}</span>
+  </span>
+</template>
+
+<style scoped>
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  line-height: 1;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.pill-label {
+  color: rgb(148 163 184); /* slate-400 */
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+.pill-value {
+  color: rgb(241 245 249); /* slate-100 */
+  font-weight: 500;
+}
+
+.pill-green { background: rgba(16, 185, 129, 0.12); border-color: rgba(16, 185, 129, 0.3); }
+.pill-green .dot { background: rgb(16 185 129); box-shadow: 0 0 0 2px rgba(16,185,129,0.2); }
+.pill-amber { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.3); }
+.pill-amber .dot { background: rgb(245 158 11); box-shadow: 0 0 0 2px rgba(245,158,11,0.2); }
+.pill-red { background: rgba(239, 68, 68, 0.15); border-color: rgba(239, 68, 68, 0.35); }
+.pill-red .dot { background: rgb(239 68 68); box-shadow: 0 0 0 2px rgba(239,68,68,0.2); }
+.pill-gray { background: rgba(71, 85, 105, 0.2); border-color: rgba(71, 85, 105, 0.4); }
+.pill-gray .dot { background: rgb(100 116 139); }
+.pill-gray .pill-value { color: rgb(148 163 184); }
+</style>

--- a/components/ReadinessStrip.vue
+++ b/components/ReadinessStrip.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+// ReadinessStrip — slim, always-visible top bar that shows live FC + flight
+// readiness at a glance. Sources telemetry from mavlink2rest (via
+// useTelemetry()). Hidden on the index/landing page; visible on every other
+// route so users always know vehicle state.
+//
+// Pills (left → right):
+//   FC          connection + age
+//   Mode        flight mode + armed/disarmed
+//   Battery     % + V/cell
+//   EKF         fusion state (flow + range fusing?)
+//   Range       laser range (m)
+//   Alt         relative altitude (m)
+//   Speed       ground + climb (m/s)
+//   Heading     deg
+//
+// Each pill: color-coded green/amber/red/gray depending on its own health.
+
+import { computed } from 'vue'
+import { useTelemetry } from '~/composables/useTelemetry'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const { telemetry, perCellVoltage, ageMs } = useTelemetry()
+
+// Hide on the landing page so it doesn't get in the way of the home grid.
+const visible = computed(() => route.path !== '/' && route.path !== '/index')
+
+const fmt = (n: number | null, d = 1) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(d))
+
+// ---- Pill state derivations ----
+type PillState = 'green' | 'amber' | 'red' | 'gray'
+
+const fc = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected) return { state: 'red', label: t.lastHeartbeatMs === 0 ? 'no link' : `lost ${(ageMs.value / 1000).toFixed(0)}s` }
+  return { state: 'green', label: 'live' }
+})
+
+const mode = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected) return { state: 'gray', label: '—' }
+  return { state: 'green', label: t.mode.name ?? '—' }
+})
+
+const armed = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected) return { state: 'gray', label: '—' }
+  return t.armed ? { state: 'red', label: 'ARMED' } : { state: 'green', label: 'disarmed' }
+})
+
+const battery = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || t.battery.voltage == null) return { state: 'gray', label: '—' }
+  const pct = t.battery.remaining
+  const v = t.battery.voltage
+  const cell = perCellVoltage.value
+  // Color by per-cell voltage primarily — remaining% sometimes lags
+  let state: PillState = 'green'
+  if (cell != null && cell < 3.3) state = 'amber'
+  if (cell != null && cell < 3.1) state = 'red'
+  const pctLabel = pct != null ? `${Math.round(pct)}%` : ''
+  const vLabel = `${v.toFixed(2)}V`
+  return { state, label: pctLabel ? `${pctLabel} · ${vLabel}` : vLabel }
+})
+
+const ekf = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || !t.ekf.flagsRaw) return { state: 'gray', label: '—' }
+  if (t.ekf.flowFusing) return { state: 'green', label: 'fusing' }
+  const acc = t.ekf.posHorizAcc
+  if (acc != null && acc < 5) return { state: 'amber', label: 'const pos' }
+  return { state: 'red', label: 'no aiding' }
+})
+
+const range = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || t.range.current == null) return { state: 'gray', label: '—' }
+  return { state: 'green', label: `${fmt(t.range.current, 2)}m` }
+})
+
+const altitude = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || t.altitude.relative == null) return { state: 'gray', label: '—' }
+  return { state: 'green', label: `${fmt(t.altitude.relative, 1)}m` }
+})
+
+const speed = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || t.speed.ground == null) return { state: 'gray', label: '—' }
+  return { state: 'green', label: `${fmt(t.speed.ground, 1)}m/s` }
+})
+
+const heading = computed<{ state: PillState; label: string }>(() => {
+  const t = telemetry.value
+  if (!t.connected || t.heading == null) return { state: 'gray', label: '—' }
+  return { state: 'green', label: `${Math.round(t.heading)}°` }
+})
+</script>
+
+<template>
+  <div v-if="visible" class="readiness-strip">
+    <div class="rs-inner">
+      <Pill label="FC" :state="fc.state" :value="fc.label" />
+      <Pill label="Mode" :state="mode.state" :value="mode.label" />
+      <Pill :state="armed.state" :value="armed.label" />
+      <Pill label="Battery" :state="battery.state" :value="battery.label" />
+      <Pill label="EKF" :state="ekf.state" :value="ekf.label" />
+      <Pill label="Range" :state="range.state" :value="range.label" />
+      <Pill label="Alt" :state="altitude.state" :value="altitude.label" />
+      <Pill label="Spd" :state="speed.state" :value="speed.label" />
+      <Pill label="Hdg" :state="heading.state" :value="heading.label" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.readiness-strip {
+  background: rgb(15 23 42); /* slate-900 */
+  border-bottom: 1px solid rgb(30 41 59); /* slate-800 */
+  color: rgb(241 245 249); /* slate-100 */
+  padding: 0.4rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  font-size: 0.8rem;
+}
+.rs-inner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+</style>

--- a/composables/useTelemetry.ts
+++ b/composables/useTelemetry.ts
@@ -1,0 +1,290 @@
+// useTelemetry — module-level singleton state driven by mavlink2rest WebSocket.
+//
+// Why mavlink2rest instead of rosbridge for telemetry: PX4's micro-XRCE-DDS
+// client doesn't always re-handshake cleanly after FC power-cycles, leaving
+// `/fmu/out/*` topics with no publisher. mavlink-router + mavlink2rest is the
+// more reliable transport — same data, much simpler bridge. ROS topics
+// (cameras, AprilTag detections, custom DEXI nodes) continue to come via
+// rosbridge through useROS().
+//
+// Single WebSocket connection shared across all consumers (subscribe count
+// tracked; the socket tears down when the last consumer unmounts).
+
+import { ref, computed, onUnmounted, readonly } from 'vue'
+
+export interface Telemetry {
+  /** true when we've heard a HEARTBEAT in the last HEARTBEAT_TIMEOUT_MS */
+  connected: boolean
+  /** ms timestamp of last HEARTBEAT */
+  lastHeartbeatMs: number
+  /** wall-clock now (so consumers can compute staleness in templates) */
+  now: number
+
+  battery: {
+    voltage: number | null      // V (cell 0)
+    remaining: number | null    // 0-100 %
+    current: number | null      // A (BATTERY_STATUS.current_battery is in 0.01A units; -1 = unknown)
+  }
+  altitude: {
+    msl: number | null          // m (from ALTITUDE)
+    relative: number | null     // m above home (from VFR_HUD/ALTITUDE)
+    terrain: number | null      // m above ground (from ALTITUDE.altitude_terrain)
+  }
+  speed: {
+    ground: number | null       // m/s (VFR_HUD.groundspeed)
+    vertical: number | null     // m/s (VFR_HUD.climb)
+  }
+  heading: number | null        // deg (VFR_HUD.heading, 0-359)
+  attitude: {
+    roll: number | null         // rad (ATTITUDE)
+    pitch: number | null
+    yaw: number | null
+  }
+  mode: {
+    base: number | null         // base_mode bitmask (HEARTBEAT)
+    custom: number | null       // custom_mode (HEARTBEAT)
+    name: string | null         // best-effort decoded PX4 mode label
+  }
+  armed: boolean
+  ekf: {
+    flagsRaw: string | null     // "ATTITUDE | VELOCITY_HORIZ | …"
+    flowFusing: boolean         // VEL_HORIZ + POS_HORIZ_REL both set
+    posHorizAcc: number | null  // m
+    posVertAcc: number | null   // m
+  }
+  range: {
+    current: number | null      // m (DISTANCE_SENSOR.current_distance / 100)
+    min: number | null
+    max: number | null
+  }
+}
+
+const HEARTBEAT_TIMEOUT_MS = 3000
+const RECONNECT_DELAY_MS = 2000
+
+function newTelemetry(): Telemetry {
+  return {
+    connected: false,
+    lastHeartbeatMs: 0,
+    now: Date.now(),
+    battery: { voltage: null, remaining: null, current: null },
+    altitude: { msl: null, relative: null, terrain: null },
+    speed: { ground: null, vertical: null },
+    heading: null,
+    attitude: { roll: null, pitch: null, yaw: null },
+    mode: { base: null, custom: null, name: null },
+    armed: false,
+    ekf: { flagsRaw: null, flowFusing: false, posHorizAcc: null, posVertAcc: null },
+    range: { current: null, min: null, max: null },
+  }
+}
+
+// ---- Module-level singletons ----
+const telemetry = ref<Telemetry>(newTelemetry())
+let ws: WebSocket | null = null
+let reconnectTimer: number | null = null
+let nowTicker: number | null = null
+let consumerCount = 0
+
+function getMavlink2RestUrl(): string {
+  if (typeof window === 'undefined') return ''
+  const params = new URLSearchParams(window.location.search)
+  const host = params.get('mavlinkHost') || window.location.hostname
+  const isSecure = window.location.protocol === 'https:'
+  // mavlink2rest exposes WS at /ws/mavlink by default. Behind tunnels it may
+  // be served on a subpath; allow override via ?mavlinkPath=...
+  const customPath = params.get('mavlinkPath')
+  const protocol = isSecure ? 'wss:' : 'ws:'
+  // Default to bare 8088 (matches dexi-os config); behind https tunnels users
+  // usually proxy ws/wss to the same host on /ws/mavlink.
+  if (customPath) return `${protocol}//${host}${customPath}`
+  return `${protocol}//${host}:8088/ws/mavlink`
+}
+
+// Best-effort PX4 mode name from custom_mode (high byte = main mode).
+// PX4 packs: custom_mode = (main_mode << 16) | (sub_mode << 24)
+function decodePx4ModeName(custom: number | null): string | null {
+  if (custom == null) return null
+  const main = (custom >> 16) & 0xff
+  const sub = (custom >> 24) & 0xff
+  const mainNames: Record<number, string> = {
+    1: 'MANUAL', 2: 'ALTCTL', 3: 'POSCTL', 4: 'AUTO',
+    5: 'ACRO', 6: 'OFFBOARD', 7: 'STABILIZED', 8: 'RATTITUDE',
+  }
+  const autoSubNames: Record<number, string> = {
+    1: 'READY', 2: 'TAKEOFF', 3: 'LOITER', 4: 'MISSION',
+    5: 'RTL', 6: 'LAND', 7: 'RTGS', 8: 'FOLLOW_TARGET', 9: 'PRECLAND', 10: 'VTOL_TAKEOFF',
+  }
+  if (main === 4) return `AUTO.${autoSubNames[sub] ?? 'UNKNOWN'}`
+  return mainNames[main] ?? `UNKNOWN(${main})`
+}
+
+function handleMavlinkMessage(envelope: any) {
+  const m = envelope?.message
+  if (!m?.type) return
+  const t: string = m.type
+  const T = telemetry.value
+  switch (t) {
+    case 'HEARTBEAT': {
+      T.lastHeartbeatMs = Date.now()
+      T.connected = true
+      const base = Number(m.base_mode ?? 0)
+      T.mode.base = base
+      T.armed = (base & 0x80) !== 0  // MAV_MODE_FLAG_SAFETY_ARMED
+      T.mode.custom = Number(m.custom_mode ?? 0)
+      T.mode.name = decodePx4ModeName(T.mode.custom)
+      break
+    }
+    case 'BATTERY_STATUS': {
+      const voltages = Array.isArray(m.voltages) ? m.voltages.filter((v: number) => v !== 65535) : []
+      T.battery.voltage = voltages.length > 0 ? voltages[0] / 1000 : T.battery.voltage
+      T.battery.remaining = Number.isFinite(m.battery_remaining) && m.battery_remaining >= 0 ? m.battery_remaining : T.battery.remaining
+      // current_battery is in cA (centi-Amps); -1 = unknown
+      const ca = Number(m.current_battery)
+      T.battery.current = Number.isFinite(ca) && ca >= 0 ? ca / 100 : T.battery.current
+      break
+    }
+    case 'SYS_STATUS': {
+      // SYS_STATUS provides voltage/current too; only fill if BATTERY_STATUS hasn't yet.
+      if (T.battery.voltage == null && Number.isFinite(m.voltage_battery)) {
+        T.battery.voltage = m.voltage_battery / 1000
+      }
+      if (T.battery.current == null && Number.isFinite(m.current_battery) && m.current_battery >= 0) {
+        T.battery.current = m.current_battery / 100
+      }
+      if (T.battery.remaining == null && Number.isFinite(m.battery_remaining) && m.battery_remaining >= 0) {
+        T.battery.remaining = m.battery_remaining
+      }
+      break
+    }
+    case 'VFR_HUD': {
+      T.altitude.relative = Number.isFinite(m.alt) ? m.alt : T.altitude.relative
+      T.speed.ground = Number.isFinite(m.groundspeed) ? m.groundspeed : T.speed.ground
+      T.speed.vertical = Number.isFinite(m.climb) ? m.climb : T.speed.vertical
+      T.heading = Number.isFinite(m.heading) ? m.heading : T.heading
+      break
+    }
+    case 'ATTITUDE': {
+      T.attitude.roll = Number.isFinite(m.roll) ? m.roll : T.attitude.roll
+      T.attitude.pitch = Number.isFinite(m.pitch) ? m.pitch : T.attitude.pitch
+      T.attitude.yaw = Number.isFinite(m.yaw) ? m.yaw : T.attitude.yaw
+      break
+    }
+    case 'ESTIMATOR_STATUS': {
+      const flags = typeof m.flags === 'string' ? m.flags : null
+      T.ekf.flagsRaw = flags
+      T.ekf.flowFusing = !!flags && flags.includes('VELOCITY_HORIZ') && flags.includes('POS_HORIZ_REL')
+      T.ekf.posHorizAcc = Number.isFinite(m.pos_horiz_accuracy) ? m.pos_horiz_accuracy : T.ekf.posHorizAcc
+      T.ekf.posVertAcc = Number.isFinite(m.pos_vert_accuracy) ? m.pos_vert_accuracy : T.ekf.posVertAcc
+      break
+    }
+    case 'DISTANCE_SENSOR': {
+      // current_distance is cm (per MAVLink spec)
+      T.range.current = Number.isFinite(m.current_distance) ? m.current_distance / 100 : T.range.current
+      T.range.min = Number.isFinite(m.min_distance) ? m.min_distance / 100 : T.range.min
+      T.range.max = Number.isFinite(m.max_distance) ? m.max_distance / 100 : T.range.max
+      break
+    }
+    case 'ALTITUDE': {
+      T.altitude.msl = Number.isFinite(m.altitude_amsl) ? m.altitude_amsl : T.altitude.msl
+      T.altitude.relative = Number.isFinite(m.altitude_relative) ? m.altitude_relative : T.altitude.relative
+      T.altitude.terrain = Number.isFinite(m.altitude_terrain) ? m.altitude_terrain : T.altitude.terrain
+      break
+    }
+  }
+}
+
+function ensureConnection() {
+  if (typeof window === 'undefined') return
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return
+  const url = getMavlink2RestUrl()
+  if (!url) return
+  try {
+    ws = new WebSocket(url)
+  } catch {
+    scheduleReconnect()
+    return
+  }
+  ws.onopen = () => {
+    // nothing extra; mavlink2rest streams all messages by default
+  }
+  ws.onmessage = (ev) => {
+    try {
+      handleMavlinkMessage(JSON.parse(ev.data))
+    } catch {
+      // ignore malformed frames
+    }
+  }
+  ws.onclose = () => {
+    ws = null
+    telemetry.value.connected = false
+    scheduleReconnect()
+  }
+  ws.onerror = () => {
+    // onclose will follow; let it handle reconnect
+  }
+}
+
+function scheduleReconnect() {
+  if (consumerCount <= 0) return
+  if (reconnectTimer) return
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = null
+    ensureConnection()
+  }, RECONNECT_DELAY_MS)
+}
+
+function startNowTicker() {
+  if (nowTicker) return
+  nowTicker = window.setInterval(() => {
+    telemetry.value.now = Date.now()
+    // Drop connection flag if heartbeat has been silent too long
+    if (telemetry.value.lastHeartbeatMs > 0 && Date.now() - telemetry.value.lastHeartbeatMs > HEARTBEAT_TIMEOUT_MS) {
+      telemetry.value.connected = false
+    }
+  }, 500)
+}
+
+function stopAll() {
+  if (ws) { try { ws.close() } catch {} ws = null }
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+  if (nowTicker) { clearInterval(nowTicker); nowTicker = null }
+}
+
+/**
+ * useTelemetry — call from any component. Shares one WebSocket across all
+ * callers. Tears down when the last caller unmounts.
+ */
+export function useTelemetry() {
+  consumerCount++
+  ensureConnection()
+  startNowTicker()
+
+  onUnmounted(() => {
+    consumerCount--
+    if (consumerCount <= 0) {
+      stopAll()
+    }
+  })
+
+  // Derived helpers (cheap)
+  const cells = computed(() => {
+    // PX4 doesn't expose cell count over MAVLink directly; conservative default = 3 (DEXI-3 ships 3S).
+    // Consumers wanting more accuracy can read BAT1_N_CELLS via /api/params later.
+    return 3
+  })
+  const perCellVoltage = computed(() => {
+    const v = telemetry.value.battery.voltage
+    return v != null ? v / cells.value : null
+  })
+  const ageMs = computed(() => {
+    const last = telemetry.value.lastHeartbeatMs
+    return last > 0 ? telemetry.value.now - last : Infinity
+  })
+
+  return {
+    telemetry: readonly(telemetry),
+    perCellVoltage,
+    ageMs,
+  }
+}

--- a/composables/useTelemetry.ts
+++ b/composables/useTelemetry.ts
@@ -62,6 +62,18 @@ export interface Telemetry {
 const HEARTBEAT_TIMEOUT_MS = 3000
 const RECONNECT_DELAY_MS = 2000
 
+// Slow-rate messages — mavlink2rest's WS streams them at ~0.1 Hz (PX4 rate
+// limit), so we'd otherwise wait 10+ seconds for the pills to populate on
+// page load. Poll the HTTP cache for these on top of the WS stream.
+const SLOW_RATE_MESSAGES = [
+  'BATTERY_STATUS',
+  'SYS_STATUS',
+  'ESTIMATOR_STATUS',
+  'DISTANCE_SENSOR',
+  'ALTITUDE',
+] as const
+const SLOW_POLL_INTERVAL_MS = 2000
+
 function newTelemetry(): Telemetry {
   return {
     connected: false,
@@ -84,21 +96,20 @@ const telemetry = ref<Telemetry>(newTelemetry())
 let ws: WebSocket | null = null
 let reconnectTimer: number | null = null
 let nowTicker: number | null = null
+let slowPollTimer: number | null = null
 let consumerCount = 0
 
-function getMavlink2RestUrl(): string {
-  if (typeof window === 'undefined') return ''
+function getMavlinkBaseUrl(): { ws: string; http: string } {
+  if (typeof window === 'undefined') return { ws: '', http: '' }
   const params = new URLSearchParams(window.location.search)
   const host = params.get('mavlinkHost') || window.location.hostname
   const isSecure = window.location.protocol === 'https:'
-  // mavlink2rest exposes WS at /ws/mavlink by default. Behind tunnels it may
-  // be served on a subpath; allow override via ?mavlinkPath=...
-  const customPath = params.get('mavlinkPath')
-  const protocol = isSecure ? 'wss:' : 'ws:'
-  // Default to bare 8088 (matches dexi-os config); behind https tunnels users
-  // usually proxy ws/wss to the same host on /ws/mavlink.
-  if (customPath) return `${protocol}//${host}${customPath}`
-  return `${protocol}//${host}:8088/ws/mavlink`
+  const wsProtocol = isSecure ? 'wss:' : 'ws:'
+  const httpProtocol = isSecure ? 'https:' : 'http:'
+  return {
+    ws: `${wsProtocol}//${host}:8088/ws/mavlink`,
+    http: `${httpProtocol}//${host}:8088`,
+  }
 }
 
 // Best-effort PX4 mode name from custom_mode (high byte = main mode).
@@ -194,10 +205,36 @@ function handleMavlinkMessage(envelope: any) {
   }
 }
 
+async function pollSlowRateMessages() {
+  const { http } = getMavlinkBaseUrl()
+  if (!http) return
+  await Promise.all(
+    SLOW_RATE_MESSAGES.map(async (msgType) => {
+      try {
+        const res = await fetch(`${http}/mavlink/vehicles/1/components/1/messages/${msgType}`, {
+          signal: AbortSignal.timeout(1500),
+        })
+        if (!res.ok) return
+        const envelope = await res.json()
+        if (envelope?.message) handleMavlinkMessage(envelope)
+      } catch {
+        // ignore — slow-rate; we'll try again on next tick
+      }
+    })
+  )
+}
+
+function startSlowPoll() {
+  if (slowPollTimer) return
+  // Fire immediately so cards populate on first load, then keep ticking.
+  pollSlowRateMessages()
+  slowPollTimer = window.setInterval(pollSlowRateMessages, SLOW_POLL_INTERVAL_MS)
+}
+
 function ensureConnection() {
   if (typeof window === 'undefined') return
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return
-  const url = getMavlink2RestUrl()
+  const { ws: url } = getMavlinkBaseUrl()
   if (!url) return
   try {
     ws = new WebSocket(url)
@@ -249,6 +286,7 @@ function stopAll() {
   if (ws) { try { ws.close() } catch {} ws = null }
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
   if (nowTicker) { clearInterval(nowTicker); nowTicker = null }
+  if (slowPollTimer) { clearInterval(slowPollTimer); slowPollTimer = null }
 }
 
 /**
@@ -259,6 +297,7 @@ export function useTelemetry() {
   consumerCount++
   ensureConnection()
   startNowTicker()
+  startSlowPoll()
 
   onUnmounted(() => {
     consumerCount--

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="min-h-screen">
+    <ReadinessStrip />
     <slot />
   </div>
-</template> 
+</template>


### PR DESCRIPTION
Closes #35.

Adds a slim, always-visible top strip with color-coded pills for FC link / mode / armed / battery / EKF / range / alt / speed / heading. Hidden on the landing page; visible on every other route.

## Self-verified live against the dev kit at 192.168.4.30

After build, the strip renders:

\`\`\`
[FC live] [MODE POSCTL] [disarmed] [BATTERY 100% · 20.01V] [EKF const pos] [RANGE 0.66m] [ALT 2.3m] [SPD 0.0m/s] [HDG 71°]
\`\`\`

EKF correctly identifies amber **const pos** because the FC's \`ESTIMATOR_CONST_POS_MODE\` is set with \`pos_horiz_accuracy=0.014m\`. All other pills green and correct.

## Architecture

- **\`composables/useTelemetry.ts\`** — module-level singleton WebSocket to mavlink2rest (\`ws://<host>:8088/ws/mavlink\`). All callers share state; the connection auto-cleans when the last consumer unmounts. 2 s reconnect backoff. Plus HTTP fallback polling at 2 s intervals for slow-rate messages (\`BATTERY_STATUS\`, \`ESTIMATOR_STATUS\`, \`DISTANCE_SENSOR\`, \`SYS_STATUS\`, \`ALTITUDE\`) so pills populate within ~200 ms instead of waiting up to 10 s for the WS stream at PX4's rate.
- **\`components/Pill.vue\`** — reusable status pill (label + value + dot, four states).
- **\`components/ReadinessStrip.vue\`** — derives per-pill state from telemetry; hidden on the home page.
- **\`layouts/default.vue\`** — renders \`<ReadinessStrip />\` above page content.

## Why mavlink2rest, not rosbridge

Diagnosed this session: PX4's micro-XRCE-DDS client doesn't always re-handshake after FC power-cycles, leaving \`/fmu/out/*\` topics with no publisher even though the µROS agent is running. That's why the existing GCS page shows \"Battery N/A / Alt N/A\". mavlink2rest carries the same data over a far more reliable bridge.

rosbridge stays in the stack via the existing \`useROS()\` composable for camera streams, AprilTag detections, custom \`/dexi/*\` topics. This PR is strictly about MAVLink telemetry.

## MAVLink messages consumed

| Message | Used for |
|---|---|
| HEARTBEAT | mode, armed, connection liveness |
| BATTERY_STATUS + SYS_STATUS | voltage, current, remaining % |
| VFR_HUD | alt, groundspeed, climb, heading |
| ATTITUDE | roll, pitch, yaw |
| ESTIMATOR_STATUS | flow fusing, pos_horiz_accuracy |
| DISTANCE_SENSOR | laser range |
| ALTITUDE | MSL, relative, terrain |

Each pill greys out gracefully when its source field is absent.

## Test plan

- [x] Strip visible on \`/status\`, populated within ~200 ms (verified)
- [x] Strip hidden on \`/\` landing page (verified)
- [x] EKF correctly amber when CONST_POS_MODE set with low pos_acc
- [ ] On a flying drone with flow fusing, EKF goes green 'fusing'
- [ ] FC disconnect → FC pill turns red 'lost Xs' within 3 s
- [ ] Reconnect → all pills repopulate within ~2 s
- [ ] No console errors after multiple route changes (singleton lifecycle)