### PR TITLE
Status page diagnostics: ROS 2 µROS card + MainMenu prune

### DIFF
--- a/components/MainMenu.vue
+++ b/components/MainMenu.vue
@@ -55,18 +55,6 @@
           >
             Keyboard Control
           </button>
-          <button
-            class="w-full text-left py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
-            @click="openGitHub"
-          >
-            GitHub
-          </button>
-          <button
-            class="w-full text-left py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
-            @click="openDiscord"
-          >
-            Discord
-          </button>
         </nav>
       </div>
     </div>
@@ -89,16 +77,6 @@ const isOpen = ref(false)
 const cameraInverted = ref(false) // Camera displays right-side up by default
 
 const { keyboardControlEnabled: keyboardControlAvailable } = useDexiPlatform()
-
-const openGitHub = () => {
-  window.open('https://github.com/droneblocks', '_blank')
-  isOpen.value = false
-}
-
-const openDiscord = () => {
-  window.open('https://discord.gg/Wjw7wGf7Wn', '_blank')
-  isOpen.value = false
-}
 
 const toggleCameraRotation = () => {
   cameraInverted.value = !cameraInverted.value

--- a/components/ROS2HealthCard.vue
+++ b/components/ROS2HealthCard.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+// ROS2HealthCard — diagnostic card for the /status page. Surfaces the state
+// of the uXRCE-DDS pipe (FC ↔ micro_ros_agent ↔ ROS 2 ↔ rosbridge).
+// Purposefully independent of mavlink2rest so users can tell which side is
+// failing when telemetry goes N/A.
+
+import { computed } from 'vue'
+import { useROSHealth } from '~/composables/useROSHealth'
+
+const { health } = useROSHealth()
+
+// ---- Diagnostic verdict ----
+type Verdict = { state: 'green' | 'amber' | 'red' | 'gray'; label: string; hint: string }
+
+const verdict = computed<Verdict>(() => {
+  const h = health.value
+  if (!h.connected) {
+    return {
+      state: 'red',
+      label: 'rosbridge offline',
+      hint: 'The Pi-side rosbridge_server is unreachable. The ROS 2 stack may be down.',
+    }
+  }
+  if (h.totalTopics == null) {
+    return { state: 'gray', label: 'querying…', hint: '' }
+  }
+  if ((h.fmuTopics ?? 0) === 0) {
+    return {
+      state: 'red',
+      label: 'µROS agent not registered',
+      hint: 'No /fmu/* topics in the graph. The micro_ros_agent may not be running, or the FC has not connected.',
+    }
+  }
+  const probedTopics = h.probes.filter((p) => p.rate !== null)
+  const alive = probedTopics.filter((p) => p.alive).length
+  if (probedTopics.length > 0 && alive === 0) {
+    return {
+      state: 'red',
+      label: 'FC not publishing',
+      hint: '/fmu/* topics are advertised but no data is flowing. The FC\'s uXRCE-DDS client may need a restart — try `sudo systemctl restart dexi` or power-cycle the FC.',
+    }
+  }
+  if (probedTopics.length > 0 && alive < probedTopics.length) {
+    return {
+      state: 'amber',
+      label: 'partial flow',
+      hint: `${alive}/${probedTopics.length} critical topics receiving data. Some PX4 components may not be publishing yet.`,
+    }
+  }
+  return {
+    state: 'green',
+    label: 'healthy',
+    hint: 'All probed PX4 topics receiving data via uXRCE-DDS.',
+  }
+})
+
+// short topic display (strip /fmu/out/ prefix to save space)
+function shortTopicName(name: string): string {
+  return name.replace(/^\/fmu\/out\//, '')
+}
+</script>
+
+<template>
+  <div class="status-card">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="status-card-title mb-0">ROS 2 / µROS</h2>
+      <span
+        class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium"
+        :class="{
+          'bg-green-100 text-green-800': verdict.state === 'green',
+          'bg-amber-100 text-amber-800': verdict.state === 'amber',
+          'bg-red-100 text-red-800': verdict.state === 'red',
+          'bg-slate-200 text-slate-600': verdict.state === 'gray',
+        }"
+      >
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full"
+          :class="{
+            'bg-green-500': verdict.state === 'green',
+            'bg-amber-500': verdict.state === 'amber',
+            'bg-red-500': verdict.state === 'red',
+            'bg-slate-400': verdict.state === 'gray',
+          }"
+        />
+        {{ verdict.label }}
+      </span>
+    </div>
+
+    <div class="space-y-3">
+      <!-- rosbridge connection -->
+      <div class="status-row">
+        <span class="status-label">rosbridge</span>
+        <span class="status-value">
+          <span
+            class="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+            :class="health.connected ? 'bg-green-500' : 'bg-red-500'"
+          />
+          {{ health.connected ? 'connected' : 'offline' }}
+        </span>
+      </div>
+
+      <!-- topic counts -->
+      <div class="status-row">
+        <span class="status-label">PX4 topics (/fmu/*)</span>
+        <span class="status-value font-mono">
+          {{ health.fmuTopics ?? '—' }}
+        </span>
+      </div>
+      <div class="status-row">
+        <span class="status-label">DEXI topics (/dexi/*)</span>
+        <span class="status-value font-mono">{{ health.dexiTopics ?? '—' }}</span>
+      </div>
+      <div class="status-row">
+        <span class="status-label">Total topics</span>
+        <span class="status-value font-mono">{{ health.totalTopics ?? '—' }}</span>
+      </div>
+
+      <!-- per-topic probes -->
+      <div v-if="health.probes.length" class="border-t border-slate-100 pt-3 mt-3">
+        <div class="text-xs uppercase tracking-wide text-slate-400 mb-2 font-medium">
+          Critical PX4 topic probes
+        </div>
+        <div class="space-y-1.5">
+          <div
+            v-for="p in health.probes"
+            :key="p.name"
+            class="flex items-center gap-2 text-xs"
+          >
+            <span
+              class="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              :class="{
+                'bg-green-500': p.alive,
+                'bg-red-500': p.rate !== null && !p.alive,
+                'bg-slate-300': p.rate === null,
+              }"
+            />
+            <code class="font-mono flex-1 truncate text-slate-700" :title="p.name">
+              {{ shortTopicName(p.name) }}
+            </code>
+            <span class="font-mono text-slate-500 w-20 text-right">
+              <template v-if="p.rate === null">untyped</template>
+              <template v-else-if="p.alive">{{ p.rate.toFixed(1) }} Hz</template>
+              <template v-else>0 Hz</template>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- diagnostic hint -->
+      <div
+        v-if="verdict.hint"
+        class="border-t border-slate-100 pt-3 mt-3"
+      >
+        <p
+          class="text-xs leading-relaxed"
+          :class="{
+            'text-green-700': verdict.state === 'green',
+            'text-amber-700': verdict.state === 'amber',
+            'text-red-700': verdict.state === 'red',
+            'text-slate-500': verdict.state === 'gray',
+          }"
+        >
+          {{ verdict.hint }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/ROS2HealthCard.vue
+++ b/components/ROS2HealthCard.vue
@@ -61,9 +61,18 @@ function shortTopicName(name: string): string {
 </script>
 
 <template>
-  <div class="status-card">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="status-card-title mb-0">ROS 2 / µROS</h2>
+  <div class="bg-white rounded-xl border border-slate-200 p-6">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-3">
+        <h2 class="text-sm font-semibold text-slate-500 uppercase tracking-wider">ROS 2</h2>
+        <NuxtLink
+          to="/ros"
+          class="text-xs text-blue-600 hover:text-blue-800 hover:underline"
+          title="Open ROS 2 explorer"
+        >
+          Open explorer →
+        </NuxtLink>
+      </div>
       <span
         class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium"
         :class="{
@@ -86,39 +95,33 @@ function shortTopicName(name: string): string {
       </span>
     </div>
 
-    <div class="space-y-3">
-      <!-- rosbridge connection -->
-      <div class="status-row">
-        <span class="status-label">rosbridge</span>
-        <span class="status-value">
+    <div class="space-y-2">
+      <div class="flex items-center justify-between">
+        <span class="text-sm text-slate-500">rosbridge</span>
+        <span class="text-sm text-slate-900 font-medium flex items-center gap-1.5">
           <span
-            class="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+            class="inline-block w-2 h-2 rounded-full"
             :class="health.connected ? 'bg-green-500' : 'bg-red-500'"
           />
           {{ health.connected ? 'connected' : 'offline' }}
         </span>
       </div>
-
-      <!-- topic counts -->
-      <div class="status-row">
-        <span class="status-label">PX4 topics (/fmu/*)</span>
-        <span class="status-value font-mono">
-          {{ health.fmuTopics ?? '—' }}
-        </span>
+      <div class="flex items-center justify-between">
+        <span class="text-sm text-slate-500 font-mono">/fmu/*</span>
+        <span class="text-sm text-slate-900 font-medium font-mono">{{ health.fmuTopics ?? '—' }}</span>
       </div>
-      <div class="status-row">
-        <span class="status-label">DEXI topics (/dexi/*)</span>
-        <span class="status-value font-mono">{{ health.dexiTopics ?? '—' }}</span>
+      <div class="flex items-center justify-between">
+        <span class="text-sm text-slate-500 font-mono">/dexi/*</span>
+        <span class="text-sm text-slate-900 font-medium font-mono">{{ health.dexiTopics ?? '—' }}</span>
       </div>
-      <div class="status-row">
-        <span class="status-label">Total topics</span>
-        <span class="status-value font-mono">{{ health.totalTopics ?? '—' }}</span>
+      <div class="flex items-center justify-between">
+        <span class="text-sm text-slate-500">All topics</span>
+        <span class="text-sm text-slate-900 font-medium font-mono">{{ health.totalTopics ?? '—' }}</span>
       </div>
 
-      <!-- per-topic probes -->
       <div v-if="health.probes.length" class="border-t border-slate-100 pt-3 mt-3">
         <div class="text-xs uppercase tracking-wide text-slate-400 mb-2 font-medium">
-          Critical PX4 topic probes
+          Topic probes
         </div>
         <div class="space-y-1.5">
           <div
@@ -146,11 +149,7 @@ function shortTopicName(name: string): string {
         </div>
       </div>
 
-      <!-- diagnostic hint -->
-      <div
-        v-if="verdict.hint"
-        class="border-t border-slate-100 pt-3 mt-3"
-      >
+      <div v-if="verdict.hint" class="border-t border-slate-100 pt-3 mt-3">
         <p
           class="text-xs leading-relaxed"
           :class="{

--- a/composables/useROSHealth.ts
+++ b/composables/useROSHealth.ts
@@ -1,0 +1,202 @@
+// useROSHealth — module-level singleton that probes the ROS 2 graph via
+// rosbridge to diagnose uXRCE-DDS health *independent of mavlink2rest*.
+//
+// What it tells you:
+//   - Whether rosbridge itself is reachable (proves the Pi's ROS stack is up)
+//   - Count of advertised topics (proves DDS discovery is happening at all)
+//   - Count of /fmu/* topics (proves the micro_ros_agent registered the PX4
+//     types)
+//   - Whether key PX4 topics actually have data flowing (proves the FC's
+//     uXRCE-DDS client is publishing, not just advertised)
+//
+// The failure modes this lets users diagnose:
+//   - rosbridge down → connected=false → "ROS stack offline"
+//   - rosbridge up, no /fmu topics → agent not running → "µROS agent missing"
+//   - /fmu topics advertised, no probes flowing → handshake incomplete →
+//     "FC not publishing — try systemctl restart dexi"
+//   - Everything flowing → green
+
+import { ref, onUnmounted, readonly } from 'vue'
+import ROSLIB from 'roslib'
+import { useROS } from './useROS'
+
+export interface TopicProbe {
+  name: string
+  /** Hz observed during the last probe window; null = probe pending */
+  rate: number | null
+  /** observed messages > 0 within the window */
+  alive: boolean
+}
+
+export interface ROSHealth {
+  connected: boolean
+  lastErrorAt: number | null
+  /** total advertised topics (rosbridge rosapi/topics) */
+  totalTopics: number | null
+  /** /fmu/* topics (uXRCE-DDS registered) */
+  fmuTopics: number | null
+  /** /dexi/* topics (custom DEXI nodes) */
+  dexiTopics: number | null
+  /** rate of the per-topic probes */
+  probes: TopicProbe[]
+  /** wall-clock for staleness */
+  now: number
+}
+
+// PX4 topics we probe to determine if data is actually flowing (not just
+// advertised). Choose high-rate topics so a 2 s window is enough signal.
+const PROBE_TOPICS = [
+  '/fmu/out/vehicle_attitude',
+  '/fmu/out/battery_status_v1',
+  '/fmu/out/vehicle_local_position_v1',
+  '/fmu/out/estimator_status_flags',
+] as const
+
+const PROBE_WINDOW_MS = 2000
+const REFRESH_INTERVAL_MS = 5000
+
+// ---- Module-level singletons ----
+const health = ref<ROSHealth>({
+  connected: false,
+  lastErrorAt: null,
+  totalTopics: null,
+  fmuTopics: null,
+  dexiTopics: null,
+  probes: PROBE_TOPICS.map((name) => ({ name, rate: null, alive: false })),
+  now: Date.now(),
+})
+
+let ros: ROSLIB.Ros | null = null
+let consumerCount = 0
+let refreshTimer: number | null = null
+let nowTicker: number | null = null
+let activeProbeSubs: ROSLIB.Topic[] = []
+
+function setupConnection() {
+  if (ros) return
+  const { getROSURL } = useROS()
+  try {
+    ros = new ROSLIB.Ros({ url: getROSURL() })
+  } catch {
+    return
+  }
+  ros.on('connection', () => {
+    health.value.connected = true
+  })
+  ros.on('error', () => {
+    health.value.lastErrorAt = Date.now()
+    // close handler will reset connected
+  })
+  ros.on('close', () => {
+    health.value.connected = false
+  })
+}
+
+function refreshTopicList() {
+  if (!ros) return
+  ros.getTopics(
+    (result: any) => {
+      const topics: string[] = Array.isArray(result?.topics) ? result.topics : []
+      health.value.totalTopics = topics.length
+      health.value.fmuTopics = topics.filter((t) => t.startsWith('/fmu/')).length
+      health.value.dexiTopics = topics.filter((t) => t.startsWith('/dexi/')).length
+    },
+    () => {
+      health.value.lastErrorAt = Date.now()
+    }
+  )
+}
+
+async function getTopicType(topic: string): Promise<string | null> {
+  if (!ros) return null
+  return new Promise((resolve) => {
+    ros!.getTopicType(
+      topic,
+      (type: string) => resolve(type || null),
+      () => resolve(null)
+    )
+  })
+}
+
+async function runProbes() {
+  if (!ros || !health.value.connected) return
+  // Tear down any prior subs
+  activeProbeSubs.forEach((t) => {
+    try { t.unsubscribe() } catch {}
+  })
+  activeProbeSubs = []
+
+  // Resolve types in parallel; subscribe only to ones we can type
+  const counts: Record<string, number> = {}
+  const subs: ROSLIB.Topic[] = []
+  await Promise.all(
+    PROBE_TOPICS.map(async (name) => {
+      const type = await getTopicType(name)
+      if (!type) return
+      const t = new ROSLIB.Topic({ ros: ros!, name, messageType: type, throttle_rate: 0 })
+      counts[name] = 0
+      t.subscribe(() => {
+        counts[name] = (counts[name] ?? 0) + 1
+      })
+      subs.push(t)
+    })
+  )
+  activeProbeSubs = subs
+
+  const start = Date.now()
+  setTimeout(() => {
+    const elapsedSec = (Date.now() - start) / 1000
+    health.value.probes = PROBE_TOPICS.map((name) => {
+      const c = counts[name] ?? 0
+      return {
+        name,
+        rate: counts[name] == null ? null : c / elapsedSec, // null if we couldn't type it
+        alive: c > 0,
+      }
+    })
+    // Cleanup
+    subs.forEach((t) => {
+      try { t.unsubscribe() } catch {}
+    })
+    activeProbeSubs = []
+  }, PROBE_WINDOW_MS)
+}
+
+function startTicking() {
+  if (refreshTimer) return
+  // First pass immediately so the card populates fast
+  refreshTopicList()
+  runProbes()
+  refreshTimer = window.setInterval(() => {
+    refreshTopicList()
+    runProbes()
+  }, REFRESH_INTERVAL_MS)
+}
+
+function startNowTicker() {
+  if (nowTicker) return
+  nowTicker = window.setInterval(() => {
+    health.value.now = Date.now()
+  }, 500)
+}
+
+function stopAll() {
+  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null }
+  if (nowTicker) { clearInterval(nowTicker); nowTicker = null }
+  activeProbeSubs.forEach((t) => { try { t.unsubscribe() } catch {} })
+  activeProbeSubs = []
+  if (ros) { try { ros.close() } catch {} ros = null }
+}
+
+export function useROSHealth() {
+  if (typeof window === 'undefined') return { health: readonly(health) }
+  consumerCount++
+  setupConnection()
+  startTicking()
+  startNowTicker()
+  onUnmounted(() => {
+    consumerCount--
+    if (consumerCount <= 0) stopAll()
+  })
+  return { health: readonly(health) }
+}

--- a/pages/status.vue
+++ b/pages/status.vue
@@ -167,6 +167,9 @@
           </div>
         </div>
 
+        <!-- ROS 2 / µROS diagnostic -->
+        <ROS2HealthCard class="mb-6" />
+
         <!-- Cellular (only when a modem is present) -->
         <div v-if="cellularInterface" class="status-card mb-6">
           <h2 class="status-card-title">Cellular</h2>


### PR DESCRIPTION
## Summary
- Adds a **ROS 2 / µROS diagnostic card** to `/status` that surfaces the health of the uXRCE-DDS pipe independent of mavlink2rest — rosbridge reachability, `/fmu/*` topic count, `/dexi/*` topic count, and per-topic rate probes for `vehicle_attitude`, `battery_status_v1`, `vehicle_local_position_v1`, `estimator_status_flags`. Verdict line surfaces \"FC not publishing\", \"partial flow\", or \"healthy\" with an actionable hint.
- Trims **GitHub** + **Discord** buttons from the hamburger menu since both already live as cards on the dashboard. MainMenu now only carries cross-page actions (Dashboard, Rotate Camera, Keyboard Control).

## Commits
- `feat(status): ROS 2 / µROS diagnostic card`
- `refactor(status): simplify ROS 2 card — drop µROS, fix spacing, link to /ros`
- `refactor(MainMenu): drop GitHub + Discord buttons`

## Test plan
- [ ] Visit `/status` — confirm new ROS 2 card renders between Top Processes and the WiFi section
- [ ] Card verdict reflects current uXRCE-DDS state (healthy when all 4 probes flow, partial flow when 3/4, FC offline when 0/4)
- [ ] Open hamburger menu — confirm GitHub + Discord are gone, Dashboard / Rotate Camera / Keyboard Control remain