### PR TITLE
GCS modernization: ReadinessStrip + interactive Mode/Arm pills

### DIFF
--- a/components/FlightControls.vue
+++ b/components/FlightControls.vue
@@ -1,39 +1,6 @@
 <template>
   <div class="w-full bg-gray-900 text-white p-2 sm:p-4">
-    <!-- Telemetry Display -->
-    <div class="flex flex-wrap items-center gap-2 sm:gap-4 md:gap-6 mb-2 sm:mb-4 text-xs sm:text-sm">
-      <!-- Flight Mode -->
-      <div class="flex items-center space-x-1 sm:space-x-2">
-        <FlightModeDisplay :ros="ros" class="font-mono" />
-      </div>
-
-      <!-- Battery -->
-      <div class="flex items-center space-x-1 sm:space-x-2">
-        <span class="text-gray-400 hidden sm:inline">Battery:</span>
-        <span class="text-gray-400 sm:hidden">Bat:</span>
-        <span class="font-mono" :class="batteryColorClass">{{ batteryDisplay }}</span>
-      </div>
-
-      <!-- Altitude -->
-      <div class="flex items-center space-x-1 sm:space-x-2">
-        <span class="text-gray-400">Alt:</span>
-        <span class="font-mono text-green-400">{{ altitudeDisplay }}</span>
-      </div>
-
-      <!-- Ground Speed - hidden on very small screens -->
-      <div class="hidden sm:flex items-center space-x-1 sm:space-x-2">
-        <span class="text-gray-400">Speed:</span>
-        <span class="font-mono text-yellow-400">{{ speedDisplay }}</span>
-      </div>
-
-      <!-- Heading - hidden on small screens -->
-      <div class="hidden md:flex items-center space-x-1 sm:space-x-2">
-        <span class="text-gray-400">Heading:</span>
-        <span class="font-mono text-purple-400">{{ headingDisplay }}</span>
-      </div>
-    </div>
-
-    <!-- Control Buttons -->
+    <!-- Control Buttons (telemetry now lives in the global ReadinessStrip) -->
     <div class="flex flex-wrap items-center gap-2 sm:gap-4">
       <!-- Mode Buttons -->
       <button
@@ -92,74 +59,27 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, defineExpose } from 'vue'
+import { ref, onMounted, onBeforeUnmount, defineExpose } from 'vue'
 import ROSLIB from 'roslib'
 import { useROS } from '~/composables/useROS'
 
 const { getROSURL } = useROS()
 
-// ROS connection - make it reactive so FlightModeDisplay can properly subscribe
+// ROS connection
 const ros = ref<ROSLIB.Ros | null>(null)
 
-// State
-const navState = ref('N/A')
+// State driving the buttons
 const isArmed = ref(false)
 const isFlying = ref(false)
 const isOffboardActive = ref(false)
-const batteryPercentage = ref<number | null>(null)
-
-// Telemetry state
-const gpsLat = ref<number | null>(null)
-const gpsLon = ref<number | null>(null)
-const altitude = ref<number | null>(null)
-const groundSpeed = ref<number | null>(null)
-const heading = ref<number | null>(null)
 
 // Offboard target position (reactive so it can be updated by other components)
 const offboardTargetPosition = ref({ x: 0, y: 0, z: -1.0, yaw: 0 })
-
-// Computed properties for battery display
-const batteryDisplay = computed(() => {
-  if (batteryPercentage.value === null) return 'N/A'
-  return `${Math.round(batteryPercentage.value)}%`
-})
-
-const batteryColorClass = computed(() => {
-  if (batteryPercentage.value === null) return 'text-gray-400'
-  if (batteryPercentage.value > 50) return 'text-green-400'
-  if (batteryPercentage.value > 20) return 'text-yellow-400'
-  return 'text-red-400'
-})
-
-// Computed properties for telemetry display
-const gpsDisplay = computed(() => {
-  if (gpsLat.value === null || gpsLon.value === null) return 'No Fix'
-  return `${gpsLat.value.toFixed(6)}, ${gpsLon.value.toFixed(6)}`
-})
-
-const altitudeDisplay = computed(() => {
-  if (altitude.value === null) return 'N/A'
-  return `${altitude.value.toFixed(1)}m`
-})
-
-const speedDisplay = computed(() => {
-  if (groundSpeed.value === null) return 'N/A'
-  return `${groundSpeed.value.toFixed(1)} m/s`
-})
-
-const headingDisplay = computed(() => {
-  if (heading.value === null) return 'N/A'
-  return `${heading.value.toFixed(0)}°`
-})
 
 // Topics
 let vehicleStatusTopic: ROSLIB.Topic | null = null
 let vehicleCommandTopic: ROSLIB.Topic | null = null
 let offboardManagerTopic: ROSLIB.Topic | null = null
-let batteryStatusTopic: ROSLIB.Topic | null = null
-let gpsPositionTopic: ROSLIB.Topic | null = null
-let localPositionTopic: ROSLIB.Topic | null = null
-let attitudeTopic: ROSLIB.Topic | null = null
 
 // Vehicle status topic fallback logic
 let vehicleStatusFallbackTimer: NodeJS.Timeout | null = null
@@ -227,96 +147,11 @@ onMounted(() => {
     name: '/dexi/offboard_manager',
     messageType: 'dexi_interfaces/msg/OffboardNavCommand'
   })
-
-  // Subscribe to battery status topic
-  batteryStatusTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: '/fmu/out/battery_status',
-    messageType: 'px4_msgs/msg/BatteryStatus',
-    throttle_rate: 1000,
-    queue_length: 1,
-  })
-
-  batteryStatusTopic.subscribe((message: any) => {
-    // PX4 battery_status message has 'remaining' field as float (0.0 to 1.0)
-    if (message.remaining !== undefined) {
-      batteryPercentage.value = message.remaining * 100
-    }
-  })
-
-  // Subscribe to GPS position topic
-  gpsPositionTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: '/fmu/out/vehicle_gps_position',
-    messageType: 'px4_msgs/msg/VehicleGpsPosition',
-    throttle_rate: 1000,
-    queue_length: 1,
-  })
-
-  gpsPositionTopic.subscribe((message: any) => {
-    // GPS coordinates are already in degrees
-    if (message.latitude_deg !== undefined && message.longitude_deg !== undefined) {
-      gpsLat.value = message.latitude_deg
-      gpsLon.value = message.longitude_deg
-    }
-  })
-
-  // Subscribe to local position topic for velocity and altitude
-  localPositionTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: '/fmu/out/vehicle_local_position',
-    messageType: 'px4_msgs/msg/VehicleLocalPosition',
-    throttle_rate: 200,
-    queue_length: 1,
-  })
-
-  localPositionTopic.subscribe((message: any) => {
-    // Calculate ground speed from vx and vy
-    if (message.vx !== undefined && message.vy !== undefined) {
-      groundSpeed.value = Math.sqrt(message.vx * message.vx + message.vy * message.vy)
-    }
-    // Altitude from z position (NED frame, so negate for positive up)
-    if (message.z !== undefined) {
-      altitude.value = -message.z
-    }
-  })
-
-  // Subscribe to attitude topic for heading
-  attitudeTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: '/fmu/out/vehicle_attitude',
-    messageType: 'px4_msgs/msg/VehicleAttitude',
-    throttle_rate: 200,
-    queue_length: 1,
-  })
-
-  attitudeTopic.subscribe((message: any) => {
-    // Convert quaternion to heading (yaw in degrees)
-    if (message.q !== undefined && message.q.length >= 4) {
-      const q = message.q
-      // Calculate yaw from quaternion
-      const yaw = Math.atan2(2.0 * (q[0] * q[3] + q[1] * q[2]), 1.0 - 2.0 * (q[2] * q[2] + q[3] * q[3]))
-      // Convert to degrees and normalize to 0-360
-      heading.value = ((yaw * 180.0 / Math.PI) + 360) % 360
-    }
-  })
 })
 
 onBeforeUnmount(() => {
   if (vehicleStatusTopic) {
     vehicleStatusTopic.unsubscribe()
-  }
-  if (batteryStatusTopic) {
-    batteryStatusTopic.unsubscribe()
-  }
-  if (gpsPositionTopic) {
-    gpsPositionTopic.unsubscribe()
-  }
-  if (localPositionTopic) {
-    localPositionTopic.unsubscribe()
-  }
-  if (attitudeTopic) {
-    attitudeTopic.unsubscribe()
   }
   if (vehicleStatusFallbackTimer) {
     clearTimeout(vehicleStatusFallbackTimer)
@@ -367,7 +202,6 @@ const subscribeToVehicleStatus = (topicName: string, isFallback: boolean = false
     }
 
     // Process the vehicle status message
-    navState.value = message.nav_state
     isArmed.value = message.arming_state === 2 // 2 = ARMED
     isFlying.value = message.nav_state !== 18 && message.nav_state !== 13
   })
@@ -413,7 +247,7 @@ const sendOffboardManagerCommand = (command: string, distance_or_degrees: number
 
 const setMode = (mode: number) => {
   console.log('Setting mode:', mode)
-  
+
   // For position mode, we need to set both the base mode and custom mode
   if (mode === 2) { // POSITION mode
     // MAV_CMD_DO_SET_MODE with:
@@ -421,7 +255,7 @@ const setMode = (mode: number) => {
     // param2: PX4_CUSTOM_MAIN_MODE_POSCTL (3)
     sendCommand(176, 1, 3)
     console.log('Setting position mode with custom mode enabled')
-  } 
+  }
   // For takeoff mode, we need to set the altitude
   else if (mode === 17) { // TAKEOFF mode
     sendCommand(22, 0, 0, 0, 0, 0, 0, 3.0) // MAV_CMD_NAV_TAKEOFF with 3m altitude
@@ -489,4 +323,4 @@ defineExpose({
   isOffboardActive,
   offboardTargetPosition
 })
-</script> 
+</script>

--- a/components/FlightControls.vue
+++ b/components/FlightControls.vue
@@ -1,249 +1,27 @@
 <template>
-  <div class="w-full bg-gray-900 text-white p-2 sm:p-4">
-    <div class="flex flex-wrap items-center gap-2 sm:gap-3">
-      <!-- Flight Mode Dropdown -->
-      <div class="relative">
-        <button
-          @click="modeMenuOpen = !modeMenuOpen"
-          class="px-3 py-1.5 text-xs sm:text-sm bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-2"
-        >
-          <span class="font-mono">{{ currentModeLabel }}</span>
-          <svg class="w-3 h-3" viewBox="0 0 12 12" fill="currentColor"><path d="M2 4l4 4 4-4z" /></svg>
-        </button>
-        <div
-          v-if="modeMenuOpen"
-          v-click-outside="closeModeMenu"
-          class="absolute z-50 mt-1 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-lg overflow-hidden"
-        >
-          <button
-            v-for="m in FLIGHT_MODES"
-            :key="m.label"
-            @click="selectMode(m)"
-            class="w-full text-left px-3 py-2 text-xs sm:text-sm hover:bg-blue-600 flex items-center justify-between"
-            :class="{ 'bg-blue-600/40': isCurrentMode(m) }"
-          >
-            <span>{{ m.label }}</span>
-            <span v-if="m.hint" class="text-gray-400 text-xs">{{ m.hint }}</span>
-          </button>
-        </div>
-      </div>
-
-      <!-- Two-step Arm Button -->
-      <button
-        v-if="!isArmed"
-        @click="onArmClick"
-        class="px-3 py-1.5 text-xs sm:text-sm rounded-lg transition-colors"
-        :class="armPhase === 'confirming'
-          ? 'bg-amber-500 hover:bg-amber-600 text-black font-semibold animate-pulse'
-          : 'bg-red-600 hover:bg-red-700'"
-      >
-        {{ armPhase === 'confirming' ? `Confirm Arm (${armCountdown}s)` : 'Arm' }}
-      </button>
-      <button
-        v-else
-        @click="disarmDrone"
-        class="px-3 py-1.5 text-xs sm:text-sm bg-green-600 hover:bg-green-700 rounded-lg"
-        title="Click to disarm"
-      >
-        Armed
-      </button>
-
-      <!-- Land Button -->
-      <button
-        @click="land"
-        :disabled="!isFlying"
-        class="px-3 py-1.5 text-xs sm:text-sm bg-yellow-600 rounded-lg hover:bg-yellow-700 disabled:opacity-50"
-      >
-        Land
-      </button>
-
-      <!-- Offboard toggle (kept hidden — wired for future use) -->
-      <button
-        @click="toggleOffboardMode"
-        class="px-3 py-1.5 text-xs sm:text-sm rounded-lg"
-        :class="isOffboardActive ? 'bg-green-600 hover:bg-green-700' : 'bg-blue-600 hover:bg-blue-700'"
-        style="display: none"
-      >
-        {{ isOffboardActive ? 'Disable Offboard' : 'Offboard Mode' }}
-      </button>
-    </div>
-  </div>
+  <!--
+    FlightControls used to render the inline GCS button bar (Mode/Arm/Land).
+    Those controls are now part of the interactive ReadinessStrip, so this
+    component is a logic-only shell that exposes the offboard helpers that
+    GCSLayout reads via flightControlsRef.
+  -->
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, defineExpose } from 'vue'
+import { ref, onMounted, onBeforeUnmount, defineExpose } from 'vue'
 import ROSLIB from 'roslib'
 import { useROS } from '~/composables/useROS'
-import { useTelemetry } from '~/composables/useTelemetry'
 
 const { getROSURL } = useROS()
-const { telemetry } = useTelemetry()
 
-// ROS connection
 const ros = ref<ROSLIB.Ros | null>(null)
-
-// State driving the buttons
-const isArmed = ref(false)
-const isFlying = ref(false)
 const isOffboardActive = ref(false)
-const navState = ref<number | null>(null)
-
-// Offboard target position (reactive so it can be updated by other components)
 const offboardTargetPosition = ref({ x: 0, y: 0, z: -1.0, yaw: 0 })
 
-// Flight-mode dropdown -------------------------------------------------------
-// PX4 custom-mode mapping (main, sub). 0 sub = N/A. Drives MAV_CMD_DO_SET_MODE.
-interface FlightMode {
-  label: string
-  main: number
-  sub: number
-  hint?: string
-}
-const FLIGHT_MODES: FlightMode[] = [
-  { label: 'Manual',     main: 1, sub: 0 },
-  { label: 'Altitude',   main: 2, sub: 0 },
-  { label: 'Position',   main: 3, sub: 0, hint: 'POSCTL' },
-  { label: 'Stabilized', main: 7, sub: 0 },
-  { label: 'Hold',       main: 4, sub: 3, hint: 'LOITER' },
-  { label: 'Takeoff',    main: 4, sub: 2 },
-  { label: 'Land',       main: 4, sub: 6 },
-  { label: 'Return',     main: 4, sub: 5, hint: 'RTL' },
-  { label: 'Mission',    main: 4, sub: 4 },
-  { label: 'Offboard',   main: 6, sub: 0 },
-]
-
-const modeMenuOpen = ref(false)
-const closeModeMenu = () => { modeMenuOpen.value = false }
-
-// Decode the current (main, sub) tuple from HEARTBEAT.custom_mode so we can
-// both render a label and highlight the matching dropdown row.
-const currentModeTuple = computed<{ main: number | null; sub: number | null }>(() => {
-  const custom = telemetry.value.mode.custom
-  if (custom == null) return { main: null, sub: null }
-  return {
-    main: (custom >> 16) & 0xff,
-    sub: (custom >> 24) & 0xff,
-  }
-})
-const currentModeLabel = computed(() => {
-  const { main, sub } = currentModeTuple.value
-  if (main == null) return 'MODE —'
-  const m = FLIGHT_MODES.find((x) => x.main === main && x.sub === sub)
-  if (m) return m.label.toUpperCase()
-  // Fall back to the raw PX4 name (POSCTL / AUTO.LOITER / …)
-  return (telemetry.value.mode.name || 'MODE ?').toUpperCase()
-})
-const isCurrentMode = (m: FlightMode) => {
-  const { main, sub } = currentModeTuple.value
-  return main === m.main && sub === m.sub
-}
-
-const selectMode = (m: FlightMode) => {
-  modeMenuOpen.value = false
-  // MAV_CMD_DO_SET_MODE (176): param1=MAV_MODE_FLAG_CUSTOM_MODE_ENABLED (1),
-  // param2=PX4 main mode, param3=PX4 sub mode.
-  sendCommand(176, 1, m.main, m.sub)
-  console.log(`setMode → ${m.label} (main=${m.main} sub=${m.sub})`)
-}
-
-// Two-step Arm ---------------------------------------------------------------
-// First click puts the button into 'confirming' for ARM_CONFIRM_MS;
-// a second click within that window actually arms.
-const ARM_CONFIRM_MS = 3000
-const armPhase = ref<'idle' | 'confirming'>('idle')
-const armCountdown = ref(0)
-let armConfirmTimer: ReturnType<typeof setTimeout> | null = null
-let armCountdownTimer: ReturnType<typeof setInterval> | null = null
-
-const cancelArmConfirm = () => {
-  if (armConfirmTimer) { clearTimeout(armConfirmTimer); armConfirmTimer = null }
-  if (armCountdownTimer) { clearInterval(armCountdownTimer); armCountdownTimer = null }
-  armPhase.value = 'idle'
-  armCountdown.value = 0
-}
-
-const onArmClick = () => {
-  if (armPhase.value === 'idle') {
-    armPhase.value = 'confirming'
-    armCountdown.value = Math.ceil(ARM_CONFIRM_MS / 1000)
-    armCountdownTimer = setInterval(() => {
-      armCountdown.value = Math.max(0, armCountdown.value - 1)
-    }, 1000)
-    armConfirmTimer = setTimeout(cancelArmConfirm, ARM_CONFIRM_MS)
-  } else {
-    // Confirm — actually arm
-    cancelArmConfirm()
-    sendCommand(400, 1) // MAV_CMD_COMPONENT_ARM_DISARM param1=1
-  }
-}
-
-const disarmDrone = () => {
-  // Single click to disarm (matches QGC behavior — disarming is the safer action).
-  sendCommand(400, 0)
-}
-
-// Click-outside directive for closing the dropdown ---------------------------
-const vClickOutside = {
-  mounted(el: HTMLElement, binding: { value: () => void }) {
-    const handler = (e: MouseEvent) => {
-      if (!el.contains(e.target as Node)) binding.value()
-    }
-    ;(el as any).__clickOutsideHandler = handler
-    document.addEventListener('click', handler)
-  },
-  unmounted(el: HTMLElement) {
-    document.removeEventListener('click', (el as any).__clickOutsideHandler)
-  },
-}
-
-// ROS plumbing for arming/land/offboard --------------------------------------
-let vehicleStatusTopic: ROSLIB.Topic | null = null
-let vehicleCommandTopic: ROSLIB.Topic | null = null
 let offboardManagerTopic: ROSLIB.Topic | null = null
-
-let vehicleStatusFallbackTimer: NodeJS.Timeout | null = null
-let hasReceivedVehicleStatus = false
-let usingFallbackTopic = false
-
-interface VehicleCommand {
-  timestamp: number
-  param1: number
-  param2: number
-  param3: number
-  param4: number
-  param5: number
-  param6: number
-  param7: number
-  command: number
-  target_system: number
-  target_component: number
-  source_system: number
-  source_component: number
-  confirmation: number
-  from_external: boolean
-}
 
 onMounted(() => {
   ros.value = new ROSLIB.Ros({ url: getROSURL() })
-
-  ros.value.on('connection', () => console.log('FlightControls: Connected to ROS'))
-  ros.value.on('error', (e: any) => console.error('FlightControls: ROS error:', e))
-  ros.value.on('close', () => console.log('FlightControls: ROS connection closed'))
-
-  subscribeToVehicleStatus('/fmu/out/vehicle_status')
-
-  vehicleStatusFallbackTimer = setTimeout(() => {
-    if (!hasReceivedVehicleStatus && !usingFallbackTopic) {
-      console.log('No messages from /fmu/out/vehicle_status, trying /fmu/out/vehicle_status_v1')
-      subscribeToVehicleStatus('/fmu/out/vehicle_status_v1', true)
-    }
-  }, 3000)
-
-  vehicleCommandTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: '/fmu/in/vehicle_command',
-    messageType: 'px4_msgs/msg/VehicleCommand',
-  })
 
   offboardManagerTopic = new ROSLIB.Topic({
     ros: ros.value as ROSLIB.Ros,
@@ -253,57 +31,9 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  cancelArmConfirm()
-  if (vehicleStatusTopic) vehicleStatusTopic.unsubscribe()
-  if (vehicleStatusFallbackTimer) clearTimeout(vehicleStatusFallbackTimer)
   if (isOffboardActive.value) sendOffboardManagerCommand('stop_offboard_heartbeat')
   if (ros.value) ros.value.close()
 })
-
-const subscribeToVehicleStatus = (topicName: string, isFallback: boolean = false) => {
-  if (vehicleStatusTopic) vehicleStatusTopic.unsubscribe()
-  if (!ros.value) return
-
-  vehicleStatusTopic = new ROSLIB.Topic({
-    ros: ros.value as ROSLIB.Ros,
-    name: topicName,
-    messageType: 'px4_msgs/msg/VehicleStatus',
-    throttle_rate: 500,
-    queue_length: 1,
-  })
-
-  vehicleStatusTopic.subscribe((message: any) => {
-    hasReceivedVehicleStatus = true
-    if (isFallback) usingFallbackTopic = true
-    if (vehicleStatusFallbackTimer) {
-      clearTimeout(vehicleStatusFallbackTimer)
-      vehicleStatusFallbackTimer = null
-    }
-    navState.value = message.nav_state
-    isArmed.value = message.arming_state === 2
-    isFlying.value = message.nav_state !== 18 && message.nav_state !== 13
-  })
-}
-
-const sendCommand = (
-  command: number,
-  param1 = 0, param2 = 0, param3 = 0, param4 = 0,
-  param5 = 0, param6 = 0, param7 = 0,
-) => {
-  if (!vehicleCommandTopic) return
-  const cmd: VehicleCommand = {
-    timestamp: Date.now() * 1000,
-    param1, param2, param3, param4, param5, param6, param7,
-    command,
-    target_system: 1,
-    target_component: 1,
-    source_system: 1,
-    source_component: 1,
-    confirmation: 0,
-    from_external: true,
-  }
-  vehicleCommandTopic.publish(cmd)
-}
 
 const sendOffboardManagerCommand = (command: string, distance_or_degrees = 0.0) => {
   if (!offboardManagerTopic) return
@@ -311,28 +41,8 @@ const sendOffboardManagerCommand = (command: string, distance_or_degrees = 0.0) 
   offboardManagerTopic.publish(msg)
 }
 
-const land = () => {
-  sendOffboardManagerCommand('land')
-  isOffboardActive.value = false
-}
-
 const publishLocalPosition = (x: number, y: number, z: number = -1.0, yaw: number = 0) => {
   offboardTargetPosition.value = { x, y, z, yaw }
-}
-
-const toggleOffboardMode = () => {
-  if (isOffboardActive.value) stopOffboardMode()
-  else startOffboardMode()
-}
-const startOffboardMode = () => {
-  if (isOffboardActive.value) return
-  isOffboardActive.value = true
-  sendOffboardManagerCommand('start_offboard_heartbeat')
-}
-const stopOffboardMode = () => {
-  if (!isOffboardActive.value) return
-  sendOffboardManagerCommand('stop_offboard_heartbeat')
-  isOffboardActive.value = false
 }
 
 defineExpose({

--- a/components/FlightControls.vue
+++ b/components/FlightControls.vue
@@ -1,69 +1,83 @@
 <template>
   <div class="w-full bg-gray-900 text-white p-2 sm:p-4">
-    <!-- Control Buttons (telemetry now lives in the global ReadinessStrip) -->
-    <div class="flex flex-wrap items-center gap-2 sm:gap-4">
-      <!-- Mode Buttons -->
-      <button
-        @click="setMode(2)"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm bg-blue-600 rounded-lg hover:bg-blue-700"
-      >
-        <span class="hidden sm:inline">Position Mode</span>
-        <span class="sm:hidden">Pos</span>
-      </button>
-      <button
-        @click="setMode(17)"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm bg-blue-600 rounded-lg hover:bg-blue-700"
-        style="display: none"
-      >
-        Takeoff Mode
-      </button>
-      <button
-        @click="toggleOffboardMode"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm rounded-lg"
-        :class="isOffboardActive ? 'bg-green-600 hover:bg-green-700' : 'bg-blue-600 hover:bg-blue-700'"
-        style="display: none"
-      >
-        {{ isOffboardActive ? 'Disable Offboard' : 'Offboard Mode' }}
-      </button>
+    <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+      <!-- Flight Mode Dropdown -->
+      <div class="relative">
+        <button
+          @click="modeMenuOpen = !modeMenuOpen"
+          class="px-3 py-1.5 text-xs sm:text-sm bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-2"
+        >
+          <span class="font-mono">{{ currentModeLabel }}</span>
+          <svg class="w-3 h-3" viewBox="0 0 12 12" fill="currentColor"><path d="M2 4l4 4 4-4z" /></svg>
+        </button>
+        <div
+          v-if="modeMenuOpen"
+          v-click-outside="closeModeMenu"
+          class="absolute z-50 mt-1 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-lg overflow-hidden"
+        >
+          <button
+            v-for="m in FLIGHT_MODES"
+            :key="m.label"
+            @click="selectMode(m)"
+            class="w-full text-left px-3 py-2 text-xs sm:text-sm hover:bg-blue-600 flex items-center justify-between"
+            :class="{ 'bg-blue-600/40': isCurrentMode(m) }"
+          >
+            <span>{{ m.label }}</span>
+            <span v-if="m.hint" class="text-gray-400 text-xs">{{ m.hint }}</span>
+          </button>
+        </div>
+      </div>
 
-      <!-- Arm Button -->
+      <!-- Two-step Arm Button -->
       <button
-        @click="armDrone"
-        :disabled="isArmed"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm rounded-lg"
-        :class="isArmed ? 'bg-green-600' : 'bg-red-600 hover:bg-red-700'"
+        v-if="!isArmed"
+        @click="onArmClick"
+        class="px-3 py-1.5 text-xs sm:text-sm rounded-lg transition-colors"
+        :class="armPhase === 'confirming'
+          ? 'bg-amber-500 hover:bg-amber-600 text-black font-semibold animate-pulse'
+          : 'bg-red-600 hover:bg-red-700'"
       >
-        {{ isArmed ? 'Armed' : 'Arm' }}
+        {{ armPhase === 'confirming' ? `Confirm Arm (${armCountdown}s)` : 'Arm' }}
       </button>
-
-      <!-- Move Forward Button -->
       <button
-        @click="moveForward"
-        :disabled="!isFlying"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm bg-purple-600 rounded-lg hover:bg-purple-700 disabled:opacity-50"
-        style="display: none"
+        v-else
+        @click="disarmDrone"
+        class="px-3 py-1.5 text-xs sm:text-sm bg-green-600 hover:bg-green-700 rounded-lg"
+        title="Click to disarm"
       >
-        Move Forward 3m
+        Armed
       </button>
 
       <!-- Land Button -->
       <button
         @click="land"
         :disabled="!isFlying"
-        class="px-2 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm bg-yellow-600 rounded-lg hover:bg-yellow-700 disabled:opacity-50"
+        class="px-3 py-1.5 text-xs sm:text-sm bg-yellow-600 rounded-lg hover:bg-yellow-700 disabled:opacity-50"
       >
         Land
+      </button>
+
+      <!-- Offboard toggle (kept hidden — wired for future use) -->
+      <button
+        @click="toggleOffboardMode"
+        class="px-3 py-1.5 text-xs sm:text-sm rounded-lg"
+        :class="isOffboardActive ? 'bg-green-600 hover:bg-green-700' : 'bg-blue-600 hover:bg-blue-700'"
+        style="display: none"
+      >
+        {{ isOffboardActive ? 'Disable Offboard' : 'Offboard Mode' }}
       </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, defineExpose } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, defineExpose } from 'vue'
 import ROSLIB from 'roslib'
 import { useROS } from '~/composables/useROS'
+import { useTelemetry } from '~/composables/useTelemetry'
 
 const { getROSURL } = useROS()
+const { telemetry } = useTelemetry()
 
 // ROS connection
 const ros = ref<ROSLIB.Ros | null>(null)
@@ -72,21 +86,125 @@ const ros = ref<ROSLIB.Ros | null>(null)
 const isArmed = ref(false)
 const isFlying = ref(false)
 const isOffboardActive = ref(false)
+const navState = ref<number | null>(null)
 
 // Offboard target position (reactive so it can be updated by other components)
 const offboardTargetPosition = ref({ x: 0, y: 0, z: -1.0, yaw: 0 })
 
-// Topics
+// Flight-mode dropdown -------------------------------------------------------
+// PX4 custom-mode mapping (main, sub). 0 sub = N/A. Drives MAV_CMD_DO_SET_MODE.
+interface FlightMode {
+  label: string
+  main: number
+  sub: number
+  hint?: string
+}
+const FLIGHT_MODES: FlightMode[] = [
+  { label: 'Manual',     main: 1, sub: 0 },
+  { label: 'Altitude',   main: 2, sub: 0 },
+  { label: 'Position',   main: 3, sub: 0, hint: 'POSCTL' },
+  { label: 'Stabilized', main: 7, sub: 0 },
+  { label: 'Hold',       main: 4, sub: 3, hint: 'LOITER' },
+  { label: 'Takeoff',    main: 4, sub: 2 },
+  { label: 'Land',       main: 4, sub: 6 },
+  { label: 'Return',     main: 4, sub: 5, hint: 'RTL' },
+  { label: 'Mission',    main: 4, sub: 4 },
+  { label: 'Offboard',   main: 6, sub: 0 },
+]
+
+const modeMenuOpen = ref(false)
+const closeModeMenu = () => { modeMenuOpen.value = false }
+
+// Decode the current (main, sub) tuple from HEARTBEAT.custom_mode so we can
+// both render a label and highlight the matching dropdown row.
+const currentModeTuple = computed<{ main: number | null; sub: number | null }>(() => {
+  const custom = telemetry.value.mode.custom
+  if (custom == null) return { main: null, sub: null }
+  return {
+    main: (custom >> 16) & 0xff,
+    sub: (custom >> 24) & 0xff,
+  }
+})
+const currentModeLabel = computed(() => {
+  const { main, sub } = currentModeTuple.value
+  if (main == null) return 'MODE —'
+  const m = FLIGHT_MODES.find((x) => x.main === main && x.sub === sub)
+  if (m) return m.label.toUpperCase()
+  // Fall back to the raw PX4 name (POSCTL / AUTO.LOITER / …)
+  return (telemetry.value.mode.name || 'MODE ?').toUpperCase()
+})
+const isCurrentMode = (m: FlightMode) => {
+  const { main, sub } = currentModeTuple.value
+  return main === m.main && sub === m.sub
+}
+
+const selectMode = (m: FlightMode) => {
+  modeMenuOpen.value = false
+  // MAV_CMD_DO_SET_MODE (176): param1=MAV_MODE_FLAG_CUSTOM_MODE_ENABLED (1),
+  // param2=PX4 main mode, param3=PX4 sub mode.
+  sendCommand(176, 1, m.main, m.sub)
+  console.log(`setMode → ${m.label} (main=${m.main} sub=${m.sub})`)
+}
+
+// Two-step Arm ---------------------------------------------------------------
+// First click puts the button into 'confirming' for ARM_CONFIRM_MS;
+// a second click within that window actually arms.
+const ARM_CONFIRM_MS = 3000
+const armPhase = ref<'idle' | 'confirming'>('idle')
+const armCountdown = ref(0)
+let armConfirmTimer: ReturnType<typeof setTimeout> | null = null
+let armCountdownTimer: ReturnType<typeof setInterval> | null = null
+
+const cancelArmConfirm = () => {
+  if (armConfirmTimer) { clearTimeout(armConfirmTimer); armConfirmTimer = null }
+  if (armCountdownTimer) { clearInterval(armCountdownTimer); armCountdownTimer = null }
+  armPhase.value = 'idle'
+  armCountdown.value = 0
+}
+
+const onArmClick = () => {
+  if (armPhase.value === 'idle') {
+    armPhase.value = 'confirming'
+    armCountdown.value = Math.ceil(ARM_CONFIRM_MS / 1000)
+    armCountdownTimer = setInterval(() => {
+      armCountdown.value = Math.max(0, armCountdown.value - 1)
+    }, 1000)
+    armConfirmTimer = setTimeout(cancelArmConfirm, ARM_CONFIRM_MS)
+  } else {
+    // Confirm — actually arm
+    cancelArmConfirm()
+    sendCommand(400, 1) // MAV_CMD_COMPONENT_ARM_DISARM param1=1
+  }
+}
+
+const disarmDrone = () => {
+  // Single click to disarm (matches QGC behavior — disarming is the safer action).
+  sendCommand(400, 0)
+}
+
+// Click-outside directive for closing the dropdown ---------------------------
+const vClickOutside = {
+  mounted(el: HTMLElement, binding: { value: () => void }) {
+    const handler = (e: MouseEvent) => {
+      if (!el.contains(e.target as Node)) binding.value()
+    }
+    ;(el as any).__clickOutsideHandler = handler
+    document.addEventListener('click', handler)
+  },
+  unmounted(el: HTMLElement) {
+    document.removeEventListener('click', (el as any).__clickOutsideHandler)
+  },
+}
+
+// ROS plumbing for arming/land/offboard --------------------------------------
 let vehicleStatusTopic: ROSLIB.Topic | null = null
 let vehicleCommandTopic: ROSLIB.Topic | null = null
 let offboardManagerTopic: ROSLIB.Topic | null = null
 
-// Vehicle status topic fallback logic
 let vehicleStatusFallbackTimer: NodeJS.Timeout | null = null
 let hasReceivedVehicleStatus = false
 let usingFallbackTopic = false
 
-// Command interface
 interface VehicleCommand {
   timestamp: number
   param1: number
@@ -106,27 +224,14 @@ interface VehicleCommand {
 }
 
 onMounted(() => {
-  // Create ROS connection
-  ros.value = new ROSLIB.Ros({
-    url: getROSURL()
-  })
+  ros.value = new ROSLIB.Ros({ url: getROSURL() })
 
-  ros.value.on('connection', () => {
-    console.log('FlightControls: Connected to ROS')
-  })
+  ros.value.on('connection', () => console.log('FlightControls: Connected to ROS'))
+  ros.value.on('error', (e: any) => console.error('FlightControls: ROS error:', e))
+  ros.value.on('close', () => console.log('FlightControls: ROS connection closed'))
 
-  ros.value.on('error', (error: any) => {
-    console.error('FlightControls: ROS connection error:', error)
-  })
-
-  ros.value.on('close', () => {
-    console.log('FlightControls: ROS connection closed')
-  })
-
-  // Start with primary vehicle status topic
   subscribeToVehicleStatus('/fmu/out/vehicle_status')
 
-  // Set up fallback timer - if no messages received in 3 seconds, try fallback topic
   vehicleStatusFallbackTimer = setTimeout(() => {
     if (!hasReceivedVehicleStatus && !usingFallbackTopic) {
       console.log('No messages from /fmu/out/vehicle_status, trying /fmu/out/vehicle_status_v1')
@@ -134,51 +239,30 @@ onMounted(() => {
     }
   }, 3000)
 
-  // Initialize command publisher for direct PX4 commands
   vehicleCommandTopic = new ROSLIB.Topic({
     ros: ros.value as ROSLIB.Ros,
     name: '/fmu/in/vehicle_command',
-    messageType: 'px4_msgs/msg/VehicleCommand'
+    messageType: 'px4_msgs/msg/VehicleCommand',
   })
 
-  // Initialize offboard manager command publisher
   offboardManagerTopic = new ROSLIB.Topic({
     ros: ros.value as ROSLIB.Ros,
     name: '/dexi/offboard_manager',
-    messageType: 'dexi_interfaces/msg/OffboardNavCommand'
+    messageType: 'dexi_interfaces/msg/OffboardNavCommand',
   })
 })
 
 onBeforeUnmount(() => {
-  if (vehicleStatusTopic) {
-    vehicleStatusTopic.unsubscribe()
-  }
-  if (vehicleStatusFallbackTimer) {
-    clearTimeout(vehicleStatusFallbackTimer)
-  }
-  // Stop offboard heartbeat via ROS node if active
-  if (isOffboardActive.value) {
-    sendOffboardManagerCommand('stop_offboard_heartbeat')
-  }
-  // Close ROS connection
-  if (ros.value) {
-    ros.value.close()
-  }
+  cancelArmConfirm()
+  if (vehicleStatusTopic) vehicleStatusTopic.unsubscribe()
+  if (vehicleStatusFallbackTimer) clearTimeout(vehicleStatusFallbackTimer)
+  if (isOffboardActive.value) sendOffboardManagerCommand('stop_offboard_heartbeat')
+  if (ros.value) ros.value.close()
 })
 
-// Vehicle status subscription function with fallback logic
 const subscribeToVehicleStatus = (topicName: string, isFallback: boolean = false) => {
-  // Unsubscribe from existing topic if any
-  if (vehicleStatusTopic) {
-    vehicleStatusTopic.unsubscribe()
-  }
-
-  if (!ros.value) {
-    console.error('Cannot subscribe to vehicle status: ROS not connected')
-    return
-  }
-
-  console.log(`Subscribing to vehicle status topic: ${topicName}`)
+  if (vehicleStatusTopic) vehicleStatusTopic.unsubscribe()
+  if (!ros.value) return
 
   vehicleStatusTopic = new ROSLIB.Topic({
     ros: ros.value as ROSLIB.Ros,
@@ -189,138 +273,71 @@ const subscribeToVehicleStatus = (topicName: string, isFallback: boolean = false
   })
 
   vehicleStatusTopic.subscribe((message: any) => {
-    // Mark that we've received a message
     hasReceivedVehicleStatus = true
-    if (isFallback) {
-      usingFallbackTopic = true
-    }
-
-    // Clear fallback timer since we're receiving messages
+    if (isFallback) usingFallbackTopic = true
     if (vehicleStatusFallbackTimer) {
       clearTimeout(vehicleStatusFallbackTimer)
       vehicleStatusFallbackTimer = null
     }
-
-    // Process the vehicle status message
-    isArmed.value = message.arming_state === 2 // 2 = ARMED
+    navState.value = message.nav_state
+    isArmed.value = message.arming_state === 2
     isFlying.value = message.nav_state !== 18 && message.nav_state !== 13
   })
 }
 
-// Command functions
-const sendCommand = (command: number, param1: number = 0, param2: number = 0, param3: number = 0, param4: number = 0, param5: number = 0, param6: number = 0, param7: number = 0) => {
+const sendCommand = (
+  command: number,
+  param1 = 0, param2 = 0, param3 = 0, param4 = 0,
+  param5 = 0, param6 = 0, param7 = 0,
+) => {
   if (!vehicleCommandTopic) return
-
   const cmd: VehicleCommand = {
     timestamp: Date.now() * 1000,
-    param1,
-    param2,
-    param3,
-    param4,
-    param5,
-    param6,
-    param7,
+    param1, param2, param3, param4, param5, param6, param7,
     command,
     target_system: 1,
     target_component: 1,
     source_system: 1,
     source_component: 1,
     confirmation: 0,
-    from_external: true
+    from_external: true,
   }
-
   vehicleCommandTopic.publish(cmd)
 }
 
-// Send command to offboard manager node
-const sendOffboardManagerCommand = (command: string, distance_or_degrees: number = 0.0) => {
+const sendOffboardManagerCommand = (command: string, distance_or_degrees = 0.0) => {
   if (!offboardManagerTopic) return
-
-  const message = new ROSLIB.Message({
-    command: command,
-    distance_or_degrees: distance_or_degrees
-  })
-
-  offboardManagerTopic.publish(message)
-  console.log(`Sent offboard manager command: ${command}`)
-}
-
-const setMode = (mode: number) => {
-  console.log('Setting mode:', mode)
-
-  // For position mode, we need to set both the base mode and custom mode
-  if (mode === 2) { // POSITION mode
-    // MAV_CMD_DO_SET_MODE with:
-    // param1: MAV_MODE_FLAG_CUSTOM_MODE_ENABLED (1)
-    // param2: PX4_CUSTOM_MAIN_MODE_POSCTL (3)
-    sendCommand(176, 1, 3)
-    console.log('Setting position mode with custom mode enabled')
-  }
-  // For takeoff mode, we need to set the altitude
-  else if (mode === 17) { // TAKEOFF mode
-    sendCommand(22, 0, 0, 0, 0, 0, 0, 3.0) // MAV_CMD_NAV_TAKEOFF with 3m altitude
-  } else {
-    sendCommand(176, 0, mode) // MAV_CMD_DO_SET_MODE
-  }
-}
-
-const armDrone = () => {
-  sendCommand(400, 1) // MAV_CMD_COMPONENT_ARM_DISARM with param1=1 to arm
+  const msg = new ROSLIB.Message({ command, distance_or_degrees })
+  offboardManagerTopic.publish(msg)
 }
 
 const land = () => {
-  // Send land command to offboard manager - it will handle stopping heartbeat and landing
   sendOffboardManagerCommand('land')
   isOffboardActive.value = false
 }
 
-const moveForward = () => {
-  // Send move forward command to offboard manager
-  sendOffboardManagerCommand('fly_forward', 3.0)
-}
-
-// Function to publish local coordinates - not used with ROS node architecture
-// The ROS node tracks position and movements internally
 const publishLocalPosition = (x: number, y: number, z: number = -1.0, yaw: number = 0) => {
-  // Update the target position for reference
   offboardTargetPosition.value = { x, y, z, yaw }
-  console.log(`Target position updated: x=${x}m, y=${y}m, z=${z}m, yaw=${yaw}°`)
-  console.log('Note: Direct position publishing not supported with ROS node architecture')
 }
 
-// Offboard mode functions
 const toggleOffboardMode = () => {
-  if (isOffboardActive.value) {
-    stopOffboardMode()
-  } else {
-    startOffboardMode()
-  }
+  if (isOffboardActive.value) stopOffboardMode()
+  else startOffboardMode()
 }
-
 const startOffboardMode = () => {
   if (isOffboardActive.value) return
-
-  console.log('Starting offboard mode via ROS node')
   isOffboardActive.value = true
-
-  // Send command to ROS node to start offboard heartbeat
   sendOffboardManagerCommand('start_offboard_heartbeat')
 }
-
 const stopOffboardMode = () => {
   if (!isOffboardActive.value) return
-
-  console.log('Stopping offboard mode via ROS node')
-
-  // Send command to ROS node to stop offboard heartbeat
   sendOffboardManagerCommand('stop_offboard_heartbeat')
   isOffboardActive.value = false
 }
 
-// Expose functions and state for other components
 defineExpose({
   publishLocalPosition,
   isOffboardActive,
-  offboardTargetPosition
+  offboardTargetPosition,
 })
 </script>

--- a/components/Pill.vue
+++ b/components/Pill.vue
@@ -2,20 +2,38 @@
 // Reusable status pill for ReadinessStrip + future status panels.
 // `label` is the static prefix ("FC", "Battery"); `value` is the live string.
 // `state` controls color: green / amber / red / gray.
+// When `clickable`, renders as a button with hover styles and emits `click`.
 
 defineProps<{
   label?: string
   value: string
   state: 'green' | 'amber' | 'red' | 'gray'
+  clickable?: boolean
+  active?: boolean
 }>()
+
+defineEmits<{ click: [event: MouseEvent] }>()
 </script>
 
 <template>
-  <span class="pill" :class="`pill-${state}`">
+  <component
+    :is="clickable ? 'button' : 'span'"
+    :type="clickable ? 'button' : undefined"
+    class="pill"
+    :class="[`pill-${state}`, { 'pill-clickable': clickable, 'pill-active': active }]"
+    @click="(e: MouseEvent) => clickable && $emit('click', e)"
+  >
     <span class="dot" />
     <span v-if="label" class="pill-label">{{ label }}</span>
     <span class="pill-value">{{ value }}</span>
-  </span>
+    <svg
+      v-if="clickable"
+      class="caret"
+      viewBox="0 0 12 12"
+      fill="currentColor"
+      aria-hidden="true"
+    ><path d="M2 4l4 4 4-4z" /></svg>
+  </component>
 </template>
 
 <style scoped>
@@ -30,6 +48,9 @@ defineProps<{
   line-height: 1;
   white-space: nowrap;
   border: 1px solid transparent;
+  font: inherit;
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
 }
 .dot {
   width: 6px;
@@ -38,16 +59,30 @@ defineProps<{
   flex-shrink: 0;
 }
 .pill-label {
-  color: rgb(148 163 184); /* slate-400 */
+  color: rgb(148 163 184);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 0.65rem;
   font-weight: 600;
 }
 .pill-value {
-  color: rgb(241 245 249); /* slate-100 */
+  color: rgb(241 245 249);
   font-weight: 500;
 }
+.caret {
+  width: 9px;
+  height: 9px;
+  margin-left: 0.15rem;
+  color: rgb(148 163 184);
+}
+
+.pill-clickable {
+  cursor: pointer;
+  transition: filter 0.12s ease, transform 0.06s ease;
+}
+.pill-clickable:hover { filter: brightness(1.25); }
+.pill-clickable:active { transform: translateY(1px); }
+.pill-active { box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.5); }
 
 .pill-green { background: rgba(16, 185, 129, 0.12); border-color: rgba(16, 185, 129, 0.3); }
 .pill-green .dot { background: rgb(16 185 129); box-shadow: 0 0 0 2px rgba(16,185,129,0.2); }

--- a/components/ReadinessStrip.vue
+++ b/components/ReadinessStrip.vue
@@ -1,36 +1,51 @@
 <script setup lang="ts">
-// ReadinessStrip — slim, always-visible top bar that shows live FC + flight
-// readiness at a glance. Sources telemetry from mavlink2rest (via
-// useTelemetry()). Hidden on the index/landing page; visible on every other
-// route so users always know vehicle state.
-//
-// Pills (left → right):
-//   FC          connection + age
-//   Mode        flight mode + armed/disarmed
-//   Battery     % + V/cell
-//   EKF         fusion state (flow + range fusing?)
-//   Range       laser range (m)
-//   Alt         relative altitude (m)
-//   Speed       ground + climb (m/s)
-//   Heading     deg
-//
-// Each pill: color-coded green/amber/red/gray depending on its own health.
+// ReadinessStrip — slim, always-visible top bar showing FC + flight readiness.
+// Two of its pills are now interactive control surfaces:
+//   - Mode pill → opens a flight-mode dropdown (sends MAV_CMD_DO_SET_MODE)
+//   - Arm pill → 3s confirm flow (sends MAV_CMD_COMPONENT_ARM_DISARM)
+// Other pills remain read-only telemetry.
 
-import { computed } from 'vue'
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useTelemetry } from '~/composables/useTelemetry'
+import { useMavlinkCommand } from '~/composables/useMavlinkCommand'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const { telemetry, perCellVoltage, ageMs } = useTelemetry()
+const { arm, disarm, setMode } = useMavlinkCommand()
 
-// Hide on the landing page so it doesn't get in the way of the home grid.
 const visible = computed(() => route.path !== '/' && route.path !== '/index')
-
 const fmt = (n: number | null, d = 1) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(d))
 
-// ---- Pill state derivations ----
 type PillState = 'green' | 'amber' | 'red' | 'gray'
 
+// ---- Flight modes ---------------------------------------------------------
+// (main, sub) tuples for MAV_CMD_DO_SET_MODE. main=4 is AUTO with sub-modes.
+interface FlightMode { label: string; main: number; sub: number; hint?: string }
+const FLIGHT_MODES: FlightMode[] = [
+  { label: 'Manual',     main: 1, sub: 0 },
+  { label: 'Altitude',   main: 2, sub: 0 },
+  { label: 'Position',   main: 3, sub: 0, hint: 'POSCTL' },
+  { label: 'Stabilized', main: 7, sub: 0 },
+  { label: 'Hold',       main: 4, sub: 3, hint: 'LOITER' },
+  { label: 'Takeoff',    main: 4, sub: 2 },
+  { label: 'Land',       main: 4, sub: 6 },
+  { label: 'Return',     main: 4, sub: 5, hint: 'RTL' },
+  { label: 'Mission',    main: 4, sub: 4 },
+  { label: 'Offboard',   main: 6, sub: 0 },
+]
+
+const currentModeTuple = computed<{ main: number | null; sub: number | null }>(() => {
+  const custom = telemetry.value.mode.custom
+  if (custom == null) return { main: null, sub: null }
+  return { main: (custom >> 16) & 0xff, sub: (custom >> 24) & 0xff }
+})
+const isCurrentMode = (m: FlightMode) => {
+  const { main, sub } = currentModeTuple.value
+  return main === m.main && sub === m.sub
+}
+
+// ---- Pill state derivations ----------------------------------------------
 const fc = computed<{ state: PillState; label: string }>(() => {
   const t = telemetry.value
   if (!t.connected) return { state: 'red', label: t.lastHeartbeatMs === 0 ? 'no link' : `lost ${(ageMs.value / 1000).toFixed(0)}s` }
@@ -40,12 +55,15 @@ const fc = computed<{ state: PillState; label: string }>(() => {
 const mode = computed<{ state: PillState; label: string }>(() => {
   const t = telemetry.value
   if (!t.connected) return { state: 'gray', label: '—' }
-  return { state: 'green', label: t.mode.name ?? '—' }
+  const { main, sub } = currentModeTuple.value
+  const m = FLIGHT_MODES.find((x) => x.main === main && x.sub === sub)
+  return { state: 'green', label: m?.label.toUpperCase() ?? (t.mode.name ?? '—') }
 })
 
-const armed = computed<{ state: PillState; label: string }>(() => {
+const armPill = computed<{ state: PillState; label: string }>(() => {
   const t = telemetry.value
   if (!t.connected) return { state: 'gray', label: '—' }
+  if (armPhase.value === 'confirming') return { state: 'amber', label: `confirm (${armCountdown.value}s)` }
   return t.armed ? { state: 'red', label: 'ARMED' } : { state: 'green', label: 'disarmed' }
 })
 
@@ -55,7 +73,6 @@ const battery = computed<{ state: PillState; label: string }>(() => {
   const pct = t.battery.remaining
   const v = t.battery.voltage
   const cell = perCellVoltage.value
-  // Color by per-cell voltage primarily — remaining% sometimes lags
   let state: PillState = 'green'
   if (cell != null && cell < 3.3) state = 'amber'
   if (cell != null && cell < 3.1) state = 'red'
@@ -96,14 +113,108 @@ const heading = computed<{ state: PillState; label: string }>(() => {
   if (!t.connected || t.heading == null) return { state: 'gray', label: '—' }
   return { state: 'green', label: `${Math.round(t.heading)}°` }
 })
+
+// ---- Mode dropdown --------------------------------------------------------
+const modeMenuOpen = ref(false)
+const modeMenuEl = ref<HTMLElement | null>(null)
+const toggleModeMenu = () => {
+  modeMenuOpen.value = !modeMenuOpen.value
+  if (modeMenuOpen.value) cancelArmConfirm()
+}
+const selectMode = async (m: FlightMode) => {
+  modeMenuOpen.value = false
+  await setMode(m.main, m.sub)
+  console.log(`setMode → ${m.label} (main=${m.main} sub=${m.sub})`)
+}
+
+// ---- Two-step Arm ---------------------------------------------------------
+const ARM_CONFIRM_MS = 3000
+const armPhase = ref<'idle' | 'confirming'>('idle')
+const armCountdown = ref(0)
+let armConfirmTimer: ReturnType<typeof setTimeout> | null = null
+let armCountdownTimer: ReturnType<typeof setInterval> | null = null
+
+const cancelArmConfirm = () => {
+  if (armConfirmTimer) { clearTimeout(armConfirmTimer); armConfirmTimer = null }
+  if (armCountdownTimer) { clearInterval(armCountdownTimer); armCountdownTimer = null }
+  armPhase.value = 'idle'
+  armCountdown.value = 0
+}
+
+const onArmPillClick = async () => {
+  // Disarming is the safer action — single click commits.
+  if (telemetry.value.armed) {
+    cancelArmConfirm()
+    await disarm()
+    console.log('arm → DISARM')
+    return
+  }
+  // Arming → two-step confirmation
+  if (armPhase.value === 'confirming') {
+    cancelArmConfirm()
+    await arm()
+    console.log('arm → ARM (confirmed)')
+    return
+  }
+  armPhase.value = 'confirming'
+  armCountdown.value = Math.ceil(ARM_CONFIRM_MS / 1000)
+  armCountdownTimer = setInterval(() => {
+    armCountdown.value = Math.max(0, armCountdown.value - 1)
+  }, 1000)
+  armConfirmTimer = setTimeout(cancelArmConfirm, ARM_CONFIRM_MS)
+}
+
+// ---- Close menu / arm-confirm on outside click ----------------------------
+const onDocClick = (e: MouseEvent) => {
+  if (modeMenuOpen.value && modeMenuEl.value && !modeMenuEl.value.contains(e.target as Node)) {
+    modeMenuOpen.value = false
+  }
+}
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  cancelArmConfirm()
+})
 </script>
 
 <template>
   <div v-if="visible" class="readiness-strip">
     <div class="rs-inner">
       <Pill label="FC" :state="fc.state" :value="fc.label" />
-      <Pill label="Mode" :state="mode.state" :value="mode.label" />
-      <Pill :state="armed.state" :value="armed.label" />
+
+      <!-- Mode pill + dropdown -->
+      <div ref="modeMenuEl" class="rs-anchor">
+        <Pill
+          label="Mode"
+          :state="mode.state"
+          :value="mode.label"
+          clickable
+          :active="modeMenuOpen"
+          @click="toggleModeMenu"
+        />
+        <div v-if="modeMenuOpen" class="rs-popover">
+          <button
+            v-for="m in FLIGHT_MODES"
+            :key="m.label"
+            class="rs-popover-item"
+            :class="{ 'rs-popover-item-current': isCurrentMode(m) }"
+            @click="selectMode(m)"
+          >
+            <span>{{ m.label }}</span>
+            <span v-if="m.hint" class="rs-popover-hint">{{ m.hint }}</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Arm pill with two-step confirm -->
+      <Pill
+        :state="armPill.state"
+        :value="armPill.label"
+        clickable
+        :active="armPhase === 'confirming'"
+        @click="onArmPillClick"
+      />
+
       <Pill label="Battery" :state="battery.state" :value="battery.label" />
       <Pill label="EKF" :state="ekf.state" :value="ekf.label" />
       <Pill label="Range" :state="range.state" :value="range.label" />
@@ -116,9 +227,9 @@ const heading = computed<{ state: PillState; label: string }>(() => {
 
 <style scoped>
 .readiness-strip {
-  background: rgb(15 23 42); /* slate-900 */
-  border-bottom: 1px solid rgb(30 41 59); /* slate-800 */
-  color: rgb(241 245 249); /* slate-100 */
+  background: rgb(15 23 42);
+  border-bottom: 1px solid rgb(30 41 59);
+  color: rgb(241 245 249);
   padding: 0.4rem 1rem;
   position: sticky;
   top: 0;
@@ -132,5 +243,46 @@ const heading = computed<{ state: PillState; label: string }>(() => {
   flex-wrap: wrap;
   max-width: 1400px;
   margin: 0 auto;
+}
+.rs-anchor {
+  position: relative;
+  display: inline-flex;
+}
+.rs-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 180px;
+  background: rgb(30 41 59);
+  border: 1px solid rgb(51 65 85);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  padding: 0.25rem;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+.rs-popover-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: rgb(241 245 249);
+  font-family: ui-monospace, monospace;
+  font-size: 0.78rem;
+  cursor: pointer;
+  text-align: left;
+}
+.rs-popover-item:hover { background: rgb(51 65 85); }
+.rs-popover-item-current { background: rgba(59, 130, 246, 0.25); }
+.rs-popover-hint {
+  color: rgb(148 163 184);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 </style>

--- a/composables/useMavlinkCommand.ts
+++ b/composables/useMavlinkCommand.ts
@@ -1,0 +1,73 @@
+// useMavlinkCommand — POST MAV_CMD_* to mavlink2rest. Uses the same transport
+// as useTelemetry so we stay consistent with the readiness strip's data path.
+//
+// mavlink2rest accepts a POST to /mavlink with the same envelope it streams
+// back, and forwards it into the mavlink-router fabric.
+
+const SYSTEM_ID_GCS = 255
+const COMPONENT_ID_GCS = 190
+const TARGET_SYSTEM = 1
+const TARGET_COMPONENT = 1
+
+function getHttpBase(): string {
+  if (typeof window === 'undefined') return ''
+  const params = new URLSearchParams(window.location.search)
+  const host = params.get('mavlinkHost') || window.location.hostname
+  const proto = window.location.protocol === 'https:' ? 'https:' : 'http:'
+  return `${proto}//${host}:8088`
+}
+
+async function postEnvelope(envelope: object): Promise<boolean> {
+  try {
+    const res = await fetch(`${getHttpBase()}/mavlink`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(envelope),
+    })
+    return res.ok
+  } catch (e) {
+    console.error('mavlink command failed:', e)
+    return false
+  }
+}
+
+function commandLong(cmdName: string, params: number[] = []): object {
+  return {
+    header: { system_id: SYSTEM_ID_GCS, component_id: COMPONENT_ID_GCS, sequence: 0 },
+    message: {
+      type: 'COMMAND_LONG',
+      target_system: TARGET_SYSTEM,
+      target_component: TARGET_COMPONENT,
+      confirmation: 0,
+      command: { type: cmdName },
+      param1: params[0] ?? 0,
+      param2: params[1] ?? 0,
+      param3: params[2] ?? 0,
+      param4: params[3] ?? 0,
+      param5: params[4] ?? 0,
+      param6: params[5] ?? 0,
+      param7: params[6] ?? 0,
+    },
+  }
+}
+
+export function useMavlinkCommand() {
+  // Arm / disarm via MAV_CMD_COMPONENT_ARM_DISARM. param1=1 arm, 0 disarm.
+  // param2=21196 is the magic force flag — we don't pass it; FC enforces preflight checks.
+  function arm() {
+    return postEnvelope(commandLong('MAV_CMD_COMPONENT_ARM_DISARM', [1]))
+  }
+  function disarm() {
+    return postEnvelope(commandLong('MAV_CMD_COMPONENT_ARM_DISARM', [0]))
+  }
+
+  // Set PX4 flight mode via MAV_CMD_DO_SET_MODE.
+  // param1: base_mode bitmask — MAV_MODE_FLAG_CUSTOM_MODE_ENABLED = 1
+  // param2: PX4 main mode (1-7)
+  // param3: PX4 sub mode (0-N, only meaningful in AUTO main mode)
+  function setMode(main: number, sub: number) {
+    return postEnvelope(commandLong('MAV_CMD_DO_SET_MODE', [1, main, sub]))
+  }
+
+  return { arm, disarm, setMode, postEnvelope, commandLong }
+}

--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -2063,17 +2063,9 @@ onUnmounted(() => {
         <a href="/" class="logo-link">
           <img src="/droneblocks-icon.jpg" alt="DroneBlocks" class="logo-icon" />
         </a>
-        <div class="connection-indicator" :class="{ connected: connected, disconnected: !connected }">
-          <span class="indicator-dot"></span>
-          <span class="indicator-text hidden sm:inline">{{ connected ? 'Connected' : 'Disconnected' }}</span>
-        </div>
       </div>
 
       <div class="header-center">
-        <div class="telemetry-group">
-          <FlightModeDisplay v-if="ros" :ros="ros" />
-          <span v-else class="telemetry-item">Mode: Unknown</span>
-        </div>
         <div v-if="connected" class="telemetry-item apriltag-indicator hidden lg:flex">
           <span class="apriltag-label">🏷️ Tag:</span>
           <span class="apriltag-value" :class="{ 'tag-detected': currentAprilTagId >= 0 }">
@@ -2084,7 +2076,6 @@ onUnmounted(() => {
           <span>N: {{ nedNorth.toFixed(1) }}</span>
           <span>E: {{ nedEast.toFixed(1) }}</span>
           <span>D: {{ nedDown.toFixed(1) }}</span>
-          <span>H: {{ nedHeading.toFixed(0) }}°</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Modernizes the GCS chrome with a persistent telemetry header and interactive flight controls. Source of truth is mavlink2rest (more reliable than rosbridge for telemetry on this hardware), giving consistent state on every page.

**New `<ReadinessStrip />`** mounted in the default layout, visible on every page except `/`:
- 9 status pills (FC/Mode/Armed/Battery/EKF/Range/Alt/Speed/Heading), color-coded by health, fed by mavlink2rest WS + HTTP cache poll.
- **Mode pill** is clickable: opens a popover with all 10 PX4 modes (Manual/Altitude/Position/Stabilized/Hold/Takeoff/Land/Return/Mission/Offboard). Current mode is highlighted. Selecting sends `MAV_CMD_DO_SET_MODE` with the right (main, sub) tuple.
- **Arm pill** is clickable with a two-step confirm flow: first click → amber pulsing \"Confirm Arm (3s)\" with countdown; second click commits `MAV_CMD_COMPONENT_ARM_DISARM`. Click \"ARMED\" single-clicks to disarm.

**New composables**
- `useTelemetry` — module-level singleton WebSocket to mavlink2rest, HTTP fallback poll for slow-rate messages, auto-reconnect.
- `useMavlinkCommand` — POST COMMAND_LONG envelopes to mavlink2rest.

**Cleanup**
- `FlightControls.vue` reduced to a logic-only shell (drops Position/Arm/Land button bar — superseded by interactive pills — keeps offboard manager wiring for GCSLayout).
- `droneblocks.vue` header drops its own FlightModeDisplay + Connected indicator + heading span (strip covers them).

## Commits
- `refactor(FlightControls): drop duplicated telemetry row`
- `feat(FlightControls): two-step Arm + flight-mode dropdown (closes #36)`
- `feat(ReadinessStrip): interactive Mode + Arm pills, drop redundant control bar`
- `refactor(droneblocks): drop header items now covered by ReadinessStrip`

Closes #35, #36.

## Test plan
- [ ] ReadinessStrip appears on every page except `/`
- [ ] Pills populate within 2s of page load (HTTP fallback poll fills slow-rate messages)
- [ ] When FC heartbeat times out → Mode pill turns red with \"FC LOST Ns\"
- [ ] Click Mode pill → dropdown opens; click outside → closes; select a mode → drone receives DO_SET_MODE
- [ ] Click \"disarmed\" → enters confirm state with countdown; second click within 3s arms; no click → reverts to idle
- [ ] Click \"ARMED\" → disarms immediately
- [ ] /gcs no longer shows duplicate flight-mode/battery/alt row above tabs
- [ ] /droneblocks header lost the FlightModeDisplay and connection dot