### PR TITLE
STATUSTEXT overlay + MSG pill in ReadinessStrip (#38)

### DIFF
--- a/components/Pill.vue
+++ b/components/Pill.vue
@@ -40,17 +40,14 @@ defineEmits<{ click: [event: MouseEvent] }>()
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.2rem 0.55rem;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
   font-family: ui-monospace, monospace;
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   line-height: 1;
   white-space: nowrap;
   border: 1px solid transparent;
-  font: inherit;
-  font-family: ui-monospace, monospace;
-  font-size: 0.75rem;
 }
 .dot {
   width: 6px;
@@ -62,7 +59,7 @@ defineEmits<{ click: [event: MouseEvent] }>()
   color: rgb(148 163 184);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 0.65rem;
+  font-size: 0.68rem;
   font-weight: 600;
 }
 .pill-value {

--- a/components/ReadinessStrip.vue
+++ b/components/ReadinessStrip.vue
@@ -16,6 +16,7 @@ const { arm, disarm, setMode } = useMavlinkCommand()
 
 const visible = computed(() => route.path !== '/' && route.path !== '/index')
 const fmt = (n: number | null, d = 1) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(d))
+const connectionAge = computed(() => (ageMs.value / 1000).toFixed(0))
 
 type PillState = 'green' | 'amber' | 'red' | 'gray'
 
@@ -46,15 +47,17 @@ const isCurrentMode = (m: FlightMode) => {
 }
 
 // ---- Pill state derivations ----------------------------------------------
-const fc = computed<{ state: PillState; label: string }>(() => {
-  const t = telemetry.value
-  if (!t.connected) return { state: 'red', label: t.lastHeartbeatMs === 0 ? 'no link' : `lost ${(ageMs.value / 1000).toFixed(0)}s` }
-  return { state: 'green', label: 'live' }
-})
-
+// MODE pill carries connection state too — when the FC link is down it shows
+// "FC OFFLINE" / "FC LOST 12s" in red. That makes the standalone "FC live"
+// pill redundant, so the strip drops it.
 const mode = computed<{ state: PillState; label: string }>(() => {
   const t = telemetry.value
-  if (!t.connected) return { state: 'gray', label: '—' }
+  if (!t.connected) {
+    return {
+      state: 'red',
+      label: t.lastHeartbeatMs === 0 ? 'FC OFFLINE' : `FC LOST ${connectionAge.value}s`,
+    }
+  }
   const { main, sub } = currentModeTuple.value
   const m = FLIGHT_MODES.find((x) => x.main === main && x.sub === sub)
   return { state: 'green', label: m?.label.toUpperCase() ?? (t.mode.name ?? '—') }
@@ -180,9 +183,7 @@ onBeforeUnmount(() => {
 <template>
   <div v-if="visible" class="readiness-strip">
     <div class="rs-inner">
-      <Pill label="FC" :state="fc.state" :value="fc.label" />
-
-      <!-- Mode pill + dropdown -->
+      <!-- Mode pill + dropdown (also reflects FC link state when offline) -->
       <div ref="modeMenuEl" class="rs-anchor">
         <Pill
           label="Mode"
@@ -230,7 +231,7 @@ onBeforeUnmount(() => {
   background: rgb(15 23 42);
   border-bottom: 1px solid rgb(30 41 59);
   color: rgb(241 245 249);
-  padding: 0.4rem 1rem;
+  padding: 0.6rem 1.5rem;
   position: sticky;
   top: 0;
   z-index: 30;
@@ -239,9 +240,9 @@ onBeforeUnmount(() => {
 .rs-inner {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  max-width: 1400px;
+  max-width: 1600px;
   margin: 0 auto;
 }
 .rs-anchor {

--- a/components/ReadinessStrip.vue
+++ b/components/ReadinessStrip.vue
@@ -8,11 +8,13 @@
 import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useTelemetry } from '~/composables/useTelemetry'
 import { useMavlinkCommand } from '~/composables/useMavlinkCommand'
+import { useStatusLog } from '~/composables/useStatusLog'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const { telemetry, perCellVoltage, ageMs } = useTelemetry()
 const { arm, disarm, setMode } = useMavlinkCommand()
+const { totalCount: msgTotal, unseenCount: msgUnseen, latest: msgLatest, toggleLog } = useStatusLog()
 
 const visible = computed(() => route.path !== '/' && route.path !== '/index')
 const fmt = (n: number | null, d = 1) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(d))
@@ -117,6 +119,20 @@ const heading = computed<{ state: PillState; label: string }>(() => {
   return { state: 'green', label: `${Math.round(t.heading)}°` }
 })
 
+// Messages pill — severity of latest message drives the color, unseen count
+// drives the value. Click toggles the log panel.
+const msgPill = computed<{ state: PillState; label: string }>(() => {
+  if (msgTotal.value === 0) return { state: 'gray', label: '0' }
+  const sev = msgLatest.value?.severity ?? 6
+  let state: PillState = 'gray'
+  if (sev <= 3) state = 'red'
+  else if (sev === 4) state = 'amber'
+  else if (sev === 5) state = 'green'
+  else state = 'gray'
+  const label = msgUnseen.value > 0 ? `${msgUnseen.value} new` : String(msgTotal.value)
+  return { state, label }
+})
+
 // ---- Mode dropdown --------------------------------------------------------
 const modeMenuOpen = ref(false)
 const modeMenuEl = ref<HTMLElement | null>(null)
@@ -183,6 +199,15 @@ onBeforeUnmount(() => {
 <template>
   <div v-if="visible" class="readiness-strip">
     <div class="rs-inner">
+      <!-- Messages pill (left of MODE) -->
+      <Pill
+        label="MSG"
+        :state="msgPill.state"
+        :value="msgPill.label"
+        clickable
+        @click="toggleLog"
+      />
+
       <!-- Mode pill + dropdown (also reflects FC link state when offline) -->
       <div ref="modeMenuEl" class="rs-anchor">
         <Pill

--- a/components/StatusTextFeed.vue
+++ b/components/StatusTextFeed.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+// StatusTextFeed — scrollable list of recent PX4 STATUSTEXT messages from the
+// FC. Severity-colored. Sources from useTelemetry().statusTexts (ring buffer).
+
+import { computed, ref } from 'vue'
+import { useTelemetry } from '~/composables/useTelemetry'
+
+const { telemetry } = useTelemetry()
+const expanded = ref(true)
+
+const items = computed(() => telemetry.value.statusTexts)
+const latest = computed(() => items.value[0] ?? null)
+
+const fmtTime = (ts: number) => {
+  const d = new Date(ts)
+  return d.toLocaleTimeString('en-US', { hour12: false }) + '.' + String(d.getMilliseconds()).padStart(3, '0')
+}
+
+const sevClass = (s: number) => {
+  if (s <= 2) return 'sev-critical'  // EMERGENCY / ALERT / CRITICAL
+  if (s === 3) return 'sev-error'
+  if (s === 4) return 'sev-warning'
+  if (s === 5) return 'sev-notice'
+  return 'sev-info'
+}
+</script>
+
+<template>
+  <div class="status-feed">
+    <div class="status-feed-header" @click="expanded = !expanded">
+      <span class="title">Messages</span>
+      <span v-if="latest" class="latest" :class="sevClass(latest.severity)" :title="latest.text">
+        <span class="latest-sev">{{ latest.severityName }}</span>
+        <span class="latest-text">{{ latest.text }}</span>
+      </span>
+      <span v-else class="muted">no messages yet</span>
+      <button class="toggle" :aria-label="expanded ? 'Collapse' : 'Expand'">
+        <svg viewBox="0 0 12 12" fill="currentColor" :style="{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)' }"><path d="M2 4l4 4 4-4z" /></svg>
+      </button>
+    </div>
+    <div v-show="expanded" class="status-feed-body">
+      <div v-if="items.length === 0" class="empty">Waiting for FC messages…</div>
+      <div v-else class="rows">
+        <div v-for="(it, i) in items" :key="i" class="row" :class="sevClass(it.severity)">
+          <span class="ts">{{ fmtTime(it.ts) }}</span>
+          <span class="sev">{{ it.severityName }}</span>
+          <span class="text">{{ it.text }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.status-feed {
+  background: rgb(15 23 42);
+  color: rgb(241 245 249);
+  border: 1px solid rgb(30 41 59);
+  border-radius: 8px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  overflow: hidden;
+}
+.status-feed-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.75rem;
+  background: rgb(30 41 59);
+  cursor: pointer;
+  user-select: none;
+}
+.title {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: rgb(148 163 184);
+}
+.muted { color: rgb(100 116 139); flex: 1; }
+.latest {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+.latest-sev {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  background: rgb(51 65 85);
+}
+.latest-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.toggle {
+  background: transparent;
+  border: none;
+  color: rgb(148 163 184);
+  cursor: pointer;
+  padding: 0.15rem;
+}
+.toggle svg { width: 12px; height: 12px; transition: transform 0.15s ease; }
+
+.status-feed-body {
+  max-height: 200px;
+  overflow-y: auto;
+}
+.empty {
+  padding: 0.75rem;
+  color: rgb(100 116 139);
+  text-align: center;
+}
+.rows {
+  display: flex;
+  flex-direction: column;
+}
+.row {
+  display: grid;
+  grid-template-columns: 110px 80px 1fr;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem;
+  border-bottom: 1px solid rgba(30, 41, 59, 0.5);
+}
+.row:last-child { border-bottom: none; }
+.ts { color: rgb(100 116 139); }
+.sev {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  align-self: center;
+}
+.text { word-break: break-word; }
+
+.sev-info .sev { color: rgb(148 163 184); }
+.sev-info .text { color: rgb(226 232 240); }
+.sev-notice .sev { color: rgb(96 165 250); }
+.sev-notice .text { color: rgb(191 219 254); }
+.sev-warning .sev { color: rgb(245 158 11); }
+.sev-warning .text { color: rgb(252 211 77); }
+.sev-error .sev { color: rgb(239 68 68); }
+.sev-error .text { color: rgb(252 165 165); }
+.sev-critical .sev { color: rgb(220 38 38); }
+.sev-critical .text { color: rgb(254 202 202); font-weight: 600; }
+
+.latest.sev-warning .latest-sev { background: rgba(245, 158, 11, 0.3); color: rgb(252 211 77); }
+.latest.sev-error .latest-sev { background: rgba(239, 68, 68, 0.3); color: rgb(252 165 165); }
+.latest.sev-critical .latest-sev { background: rgba(220, 38, 38, 0.4); color: rgb(254 202 202); }
+.latest.sev-notice .latest-sev { background: rgba(59, 130, 246, 0.3); color: rgb(191 219 254); }
+</style>

--- a/components/StatusTextFeed.vue
+++ b/components/StatusTextFeed.vue
@@ -1,139 +1,281 @@
 <script setup lang="ts">
-// StatusTextFeed — scrollable list of recent PX4 STATUSTEXT messages from the
-// FC. Severity-colored. Sources from useTelemetry().statusTexts (ring buffer).
+// StatusTextFeed — QGC-style PX4 message overlay. Two surfaces:
+//   1. Transient toast that flashes at the top-center when a new STATUSTEXT
+//      arrives, auto-fades after TOAST_LIFETIME_MS.
+//   2. On-demand bottom-right log panel — small chip showing message count;
+//      click to expand into a scrollable list. Hidden by default so it
+//      doesn't compete with the camera/map view.
 
-import { computed, ref } from 'vue'
-import { useTelemetry } from '~/composables/useTelemetry'
+import { computed, ref, watch } from 'vue'
+import { useTelemetry, type StatusText } from '~/composables/useTelemetry'
 
 const { telemetry } = useTelemetry()
-const expanded = ref(true)
+
+const TOAST_LIFETIME_MS = 5000
+const TOAST_FADE_MS = 400
 
 const items = computed(() => telemetry.value.statusTexts)
-const latest = computed(() => items.value[0] ?? null)
+const latest = computed<StatusText | null>(() => items.value[0] ?? null)
 
+// ---- Toast on new message -------------------------------------------------
+const toastEntry = ref<StatusText | null>(null)
+const toastVisible = ref(false)
+let toastTimer: ReturnType<typeof setTimeout> | null = null
+let fadeTimer: ReturnType<typeof setTimeout> | null = null
+let lastToastedTs = 0
+
+watch(latest, (val) => {
+  if (!val) return
+  if (val.ts === lastToastedTs) return
+  lastToastedTs = val.ts
+  toastEntry.value = val
+  toastVisible.value = true
+  if (toastTimer) clearTimeout(toastTimer)
+  if (fadeTimer) clearTimeout(fadeTimer)
+  toastTimer = setTimeout(() => {
+    toastVisible.value = false
+    fadeTimer = setTimeout(() => { toastEntry.value = null }, TOAST_FADE_MS)
+  }, TOAST_LIFETIME_MS)
+}, { flush: 'post' })
+
+// ---- Log panel ------------------------------------------------------------
+const logOpen = ref(false)
+const lastSeenIndex = ref(0)
+const unseenCount = computed(() => Math.max(0, items.value.length - lastSeenIndex.value))
+
+const openLog = () => {
+  logOpen.value = true
+  lastSeenIndex.value = items.value.length
+}
+const closeLog = () => { logOpen.value = false }
+
+// ---- Helpers --------------------------------------------------------------
 const fmtTime = (ts: number) => {
   const d = new Date(ts)
-  return d.toLocaleTimeString('en-US', { hour12: false }) + '.' + String(d.getMilliseconds()).padStart(3, '0')
+  return d.toLocaleTimeString('en-US', { hour12: false })
 }
-
 const sevClass = (s: number) => {
-  if (s <= 2) return 'sev-critical'  // EMERGENCY / ALERT / CRITICAL
+  if (s <= 2) return 'sev-critical'
   if (s === 3) return 'sev-error'
   if (s === 4) return 'sev-warning'
   if (s === 5) return 'sev-notice'
   return 'sev-info'
 }
+const sevLabel = (s: number) => {
+  if (s <= 2) return 'CRIT'
+  if (s === 3) return 'ERR'
+  if (s === 4) return 'WARN'
+  if (s === 5) return 'NOTICE'
+  if (s === 7) return 'DEBUG'
+  return 'INFO'
+}
 </script>
 
 <template>
-  <div class="status-feed">
-    <div class="status-feed-header" @click="expanded = !expanded">
-      <span class="title">Messages</span>
-      <span v-if="latest" class="latest" :class="sevClass(latest.severity)" :title="latest.text">
-        <span class="latest-sev">{{ latest.severityName }}</span>
-        <span class="latest-text">{{ latest.text }}</span>
-      </span>
-      <span v-else class="muted">no messages yet</span>
-      <button class="toggle" :aria-label="expanded ? 'Collapse' : 'Expand'">
-        <svg viewBox="0 0 12 12" fill="currentColor" :style="{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)' }"><path d="M2 4l4 4 4-4z" /></svg>
-      </button>
-    </div>
-    <div v-show="expanded" class="status-feed-body">
-      <div v-if="items.length === 0" class="empty">Waiting for FC messages…</div>
-      <div v-else class="rows">
-        <div v-for="(it, i) in items" :key="i" class="row" :class="sevClass(it.severity)">
-          <span class="ts">{{ fmtTime(it.ts) }}</span>
-          <span class="sev">{{ it.severityName }}</span>
-          <span class="text">{{ it.text }}</span>
+  <Teleport to="body">
+    <!-- Toast: flashes top-center when a new message arrives -->
+    <Transition name="toast">
+      <div
+        v-if="toastEntry && toastVisible"
+        class="msg-toast"
+        :class="sevClass(toastEntry.severity)"
+        role="status"
+        @click="openLog"
+      >
+        <span class="toast-sev">{{ sevLabel(toastEntry.severity) }}</span>
+        <span class="toast-text">{{ toastEntry.text }}</span>
+      </div>
+    </Transition>
+
+    <!-- Persistent chip in bottom-right; click to open log panel -->
+    <button
+      v-if="items.length > 0 && !logOpen"
+      class="msg-chip"
+      :class="{ 'has-unseen': unseenCount > 0 }"
+      @click="openLog"
+      :title="`${items.length} message${items.length === 1 ? '' : 's'} — click to view`"
+    >
+      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3h12v8H5l-3 3V3zm2 2v2h8V5H4zm0 3v2h6V8H4z" /></svg>
+      <span class="chip-count">{{ items.length }}</span>
+      <span v-if="unseenCount > 0" class="chip-badge">{{ unseenCount }}</span>
+    </button>
+
+    <!-- Log panel overlay -->
+    <Transition name="panel">
+      <div v-if="logOpen" class="msg-panel">
+        <div class="panel-header">
+          <span class="panel-title">FC Messages</span>
+          <span class="panel-count">{{ items.length }}</span>
+          <button class="panel-close" @click="closeLog" aria-label="Close">×</button>
+        </div>
+        <div class="panel-body">
+          <div v-if="items.length === 0" class="empty">No messages</div>
+          <div
+            v-for="(it, i) in items"
+            :key="i"
+            class="row"
+            :class="sevClass(it.severity)"
+          >
+            <span class="ts">{{ fmtTime(it.ts) }}</span>
+            <span class="sev">{{ sevLabel(it.severity) }}</span>
+            <span class="text">{{ it.text }}</span>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
+    </Transition>
+  </Teleport>
 </template>
 
 <style scoped>
-.status-feed {
-  background: rgb(15 23 42);
-  color: rgb(241 245 249);
-  border: 1px solid rgb(30 41 59);
-  border-radius: 8px;
+/* ---- Toast (top-center) ------------------------------------------------ */
+.msg-toast {
+  position: fixed;
+  top: 4.2rem;            /* below readiness strip */
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  backdrop-filter: blur(8px);
   font-family: ui-monospace, monospace;
-  font-size: 0.75rem;
-  overflow: hidden;
-}
-.status-feed-header {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 0.75rem;
-  background: rgb(30 41 59);
+  font-size: 0.82rem;
+  color: rgb(241 245 249);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  max-width: 70vw;
   cursor: pointer;
-  user-select: none;
 }
-.title {
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.toast-sev {
   font-size: 0.65rem;
-  font-weight: 600;
-  color: rgb(148 163 184);
-}
-.muted { color: rgb(100 116 139); flex: 1; }
-.latest {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex: 1;
-  min-width: 0;
-}
-.latest-sev {
-  font-size: 0.6rem;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding: 0.05rem 0.35rem;
+  padding: 0.1rem 0.4rem;
   border-radius: 4px;
   background: rgb(51 65 85);
 }
-.latest-text {
+.toast-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.toggle {
+
+.toast-enter-active, .toast-leave-active {
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+.toast-enter-from, .toast-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -10px);
+}
+
+/* ---- Persistent chip --------------------------------------------------- */
+.msg-chip {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 55;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgb(226 232 240);
+  font-family: ui-monospace, monospace;
+  font-size: 0.72rem;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: filter 0.12s ease;
+}
+.msg-chip:hover { filter: brightness(1.3); }
+.msg-chip svg { width: 14px; height: 14px; }
+.chip-count { font-weight: 600; }
+.chip-badge {
+  background: rgb(239 68 68);
+  color: white;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+}
+
+/* ---- Log panel --------------------------------------------------------- */
+.msg-panel {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 60;
+  width: min(520px, calc(100vw - 2rem));
+  max-height: 50vh;
+  background: rgba(15, 23, 42, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  color: rgb(241 245 249);
+  font-family: ui-monospace, monospace;
+}
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+.panel-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(148 163 184);
+}
+.panel-count {
+  font-size: 0.7rem;
+  color: rgb(100 116 139);
+  flex: 1;
+}
+.panel-close {
   background: transparent;
   border: none;
   color: rgb(148 163 184);
+  font-size: 1.25rem;
+  line-height: 1;
   cursor: pointer;
-  padding: 0.15rem;
+  padding: 0 0.25rem;
 }
-.toggle svg { width: 12px; height: 12px; transition: transform 0.15s ease; }
+.panel-close:hover { color: rgb(241 245 249); }
 
-.status-feed-body {
-  max-height: 200px;
+.panel-body {
   overflow-y: auto;
+  padding: 0.25rem 0;
 }
 .empty {
-  padding: 0.75rem;
-  color: rgb(100 116 139);
+  padding: 1rem;
   text-align: center;
-}
-.rows {
-  display: flex;
-  flex-direction: column;
+  color: rgb(100 116 139);
+  font-size: 0.78rem;
 }
 .row {
   display: grid;
-  grid-template-columns: 110px 80px 1fr;
+  grid-template-columns: 70px 60px 1fr;
   gap: 0.5rem;
   padding: 0.3rem 0.75rem;
+  font-size: 0.72rem;
   border-bottom: 1px solid rgba(30, 41, 59, 0.5);
 }
 .row:last-child { border-bottom: none; }
 .ts { color: rgb(100 116 139); }
 .sev {
-  font-size: 0.6rem;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-weight: 600;
+  font-weight: 700;
   align-self: center;
 }
 .text { word-break: break-word; }
@@ -149,8 +291,22 @@ const sevClass = (s: number) => {
 .sev-critical .sev { color: rgb(220 38 38); }
 .sev-critical .text { color: rgb(254 202 202); font-weight: 600; }
 
-.latest.sev-warning .latest-sev { background: rgba(245, 158, 11, 0.3); color: rgb(252 211 77); }
-.latest.sev-error .latest-sev { background: rgba(239, 68, 68, 0.3); color: rgb(252 165 165); }
-.latest.sev-critical .latest-sev { background: rgba(220, 38, 38, 0.4); color: rgb(254 202 202); }
-.latest.sev-notice .latest-sev { background: rgba(59, 130, 246, 0.3); color: rgb(191 219 254); }
+/* Toast variants */
+.msg-toast.sev-warning { border-color: rgba(245, 158, 11, 0.5); }
+.msg-toast.sev-warning .toast-sev { background: rgba(245, 158, 11, 0.3); color: rgb(252 211 77); }
+.msg-toast.sev-error { border-color: rgba(239, 68, 68, 0.5); }
+.msg-toast.sev-error .toast-sev { background: rgba(239, 68, 68, 0.3); color: rgb(252 165 165); }
+.msg-toast.sev-critical { border-color: rgba(220, 38, 38, 0.6); }
+.msg-toast.sev-critical .toast-sev { background: rgba(220, 38, 38, 0.4); color: rgb(254 202 202); }
+.msg-toast.sev-notice { border-color: rgba(96, 165, 250, 0.4); }
+.msg-toast.sev-notice .toast-sev { background: rgba(96, 165, 250, 0.3); color: rgb(191 219 254); }
+
+/* Panel transitions */
+.panel-enter-active, .panel-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.panel-enter-from, .panel-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
 </style>

--- a/components/StatusTextFeed.vue
+++ b/components/StatusTextFeed.vue
@@ -6,16 +6,14 @@
 //      click to expand into a scrollable list. Hidden by default so it
 //      doesn't compete with the camera/map view.
 
-import { computed, ref, watch } from 'vue'
-import { useTelemetry, type StatusText } from '~/composables/useTelemetry'
+import { ref, watch } from 'vue'
+import type { StatusText } from '~/composables/useTelemetry'
+import { useStatusLog } from '~/composables/useStatusLog'
 
-const { telemetry } = useTelemetry()
+const { items, latest, logOpen, openLog, closeLog } = useStatusLog()
 
 const TOAST_LIFETIME_MS = 5000
 const TOAST_FADE_MS = 400
-
-const items = computed(() => telemetry.value.statusTexts)
-const latest = computed<StatusText | null>(() => items.value[0] ?? null)
 
 // ---- Toast on new message -------------------------------------------------
 const toastEntry = ref<StatusText | null>(null)
@@ -37,17 +35,6 @@ watch(latest, (val) => {
     fadeTimer = setTimeout(() => { toastEntry.value = null }, TOAST_FADE_MS)
   }, TOAST_LIFETIME_MS)
 }, { flush: 'post' })
-
-// ---- Log panel ------------------------------------------------------------
-const logOpen = ref(false)
-const lastSeenIndex = ref(0)
-const unseenCount = computed(() => Math.max(0, items.value.length - lastSeenIndex.value))
-
-const openLog = () => {
-  logOpen.value = true
-  lastSeenIndex.value = items.value.length
-}
-const closeLog = () => { logOpen.value = false }
 
 // ---- Helpers --------------------------------------------------------------
 const fmtTime = (ts: number) => {
@@ -87,20 +74,7 @@ const sevLabel = (s: number) => {
       </div>
     </Transition>
 
-    <!-- Persistent chip in bottom-right; click to open log panel -->
-    <button
-      v-if="items.length > 0 && !logOpen"
-      class="msg-chip"
-      :class="{ 'has-unseen': unseenCount > 0 }"
-      @click="openLog"
-      :title="`${items.length} message${items.length === 1 ? '' : 's'} — click to view`"
-    >
-      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3h12v8H5l-3 3V3zm2 2v2h8V5H4zm0 3v2h6V8H4z" /></svg>
-      <span class="chip-count">{{ items.length }}</span>
-      <span v-if="unseenCount > 0" class="chip-badge">{{ unseenCount }}</span>
-    </button>
-
-    <!-- Log panel overlay -->
+    <!-- Log panel overlay (opened via MSG pill in the readiness strip) -->
     <Transition name="panel">
       <div v-if="logOpen" class="msg-panel">
         <div class="panel-header">
@@ -170,38 +144,6 @@ const sevLabel = (s: number) => {
 .toast-enter-from, .toast-leave-to {
   opacity: 0;
   transform: translate(-50%, -10px);
-}
-
-/* ---- Persistent chip --------------------------------------------------- */
-.msg-chip {
-  position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  z-index: 55;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  color: rgb(226 232 240);
-  font-family: ui-monospace, monospace;
-  font-size: 0.72rem;
-  cursor: pointer;
-  backdrop-filter: blur(8px);
-  transition: filter 0.12s ease;
-}
-.msg-chip:hover { filter: brightness(1.3); }
-.msg-chip svg { width: 14px; height: 14px; }
-.chip-count { font-weight: 600; }
-.chip-badge {
-  background: rgb(239 68 68);
-  color: white;
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 0.05rem 0.4rem;
-  font-size: 0.65rem;
 }
 
 /* ---- Log panel --------------------------------------------------------- */

--- a/composables/useStatusLog.ts
+++ b/composables/useStatusLog.ts
@@ -1,0 +1,38 @@
+// useStatusLog — module-level state for the STATUSTEXT log panel so that the
+// chip (ReadinessStrip) and the panel (StatusTextFeed) can sit in different
+// components and still agree on open/close + unseen tracking.
+
+import { computed, ref } from 'vue'
+import { useTelemetry } from './useTelemetry'
+
+const logOpen = ref(false)
+const lastSeenCount = ref(0)
+
+export function useStatusLog() {
+  const { telemetry } = useTelemetry()
+  const items = computed(() => telemetry.value.statusTexts)
+  const totalCount = computed(() => items.value.length)
+  const unseenCount = computed(() => Math.max(0, totalCount.value - lastSeenCount.value))
+  const latest = computed(() => items.value[0] ?? null)
+
+  const openLog = () => {
+    logOpen.value = true
+    lastSeenCount.value = totalCount.value
+  }
+  const closeLog = () => { logOpen.value = false }
+  const toggleLog = () => {
+    if (logOpen.value) closeLog()
+    else openLog()
+  }
+
+  return {
+    logOpen,
+    items,
+    totalCount,
+    unseenCount,
+    latest,
+    openLog,
+    closeLog,
+    toggleLog,
+  }
+}

--- a/composables/useTelemetry.ts
+++ b/composables/useTelemetry.ts
@@ -57,7 +57,21 @@ export interface Telemetry {
     min: number | null
     max: number | null
   }
+  /** Most recent STATUSTEXT messages from the FC (newest first). */
+  statusTexts: StatusText[]
 }
+
+export interface StatusText {
+  ts: number       // ms
+  text: string
+  severity: number // 0=EMERGENCY, 1=ALERT, 2=CRITICAL, 3=ERROR, 4=WARNING, 5=NOTICE, 6=INFO, 7=DEBUG
+  severityName: 'EMERGENCY' | 'ALERT' | 'CRITICAL' | 'ERROR' | 'WARNING' | 'NOTICE' | 'INFO' | 'DEBUG'
+}
+
+const STATUSTEXT_BUFFER = 50
+const SEVERITY_NAMES: StatusText['severityName'][] = [
+  'EMERGENCY', 'ALERT', 'CRITICAL', 'ERROR', 'WARNING', 'NOTICE', 'INFO', 'DEBUG',
+]
 
 const HEARTBEAT_TIMEOUT_MS = 3000
 const RECONNECT_DELAY_MS = 2000
@@ -88,6 +102,7 @@ function newTelemetry(): Telemetry {
     armed: false,
     ekf: { flagsRaw: null, flowFusing: false, posHorizAcc: null, posVertAcc: null },
     range: { current: null, min: null, max: null },
+    statusTexts: [],
   }
 }
 
@@ -200,6 +215,36 @@ function handleMavlinkMessage(envelope: any) {
       T.altitude.msl = Number.isFinite(m.altitude_amsl) ? m.altitude_amsl : T.altitude.msl
       T.altitude.relative = Number.isFinite(m.altitude_relative) ? m.altitude_relative : T.altitude.relative
       T.altitude.terrain = Number.isFinite(m.altitude_terrain) ? m.altitude_terrain : T.altitude.terrain
+      break
+    }
+    case 'STATUSTEXT': {
+      // text is fixed-length; trim trailing nulls / padding
+      const raw = typeof m.text === 'string' ? m.text : Array.isArray(m.text) ? m.text.join('') : ''
+      const text = raw.replace(/\0/g, '').trim()
+      if (!text) break
+      const sev = Number.isFinite(m.severity?.type ? -1 : m.severity) ? Number(m.severity) : 6
+      // mavlink2rest may send severity as { type: 'MAV_SEVERITY_INFO' } or a raw int
+      let sevNum = 6
+      if (typeof m.severity === 'number') sevNum = m.severity
+      else if (m.severity?.type) {
+        const mapping: Record<string, number> = {
+          MAV_SEVERITY_EMERGENCY: 0, MAV_SEVERITY_ALERT: 1, MAV_SEVERITY_CRITICAL: 2,
+          MAV_SEVERITY_ERROR: 3, MAV_SEVERITY_WARNING: 4, MAV_SEVERITY_NOTICE: 5,
+          MAV_SEVERITY_INFO: 6, MAV_SEVERITY_DEBUG: 7,
+        }
+        sevNum = mapping[m.severity.type] ?? 6
+      }
+      const entry: StatusText = {
+        ts: Date.now(),
+        text,
+        severity: sevNum,
+        severityName: SEVERITY_NAMES[sevNum] ?? 'INFO',
+      }
+      // Dedupe consecutive identical messages within 500ms (PX4 multi-frag STATUSTEXT)
+      const last = T.statusTexts[0]
+      if (last && last.text === entry.text && entry.ts - last.ts < 500) break
+      T.statusTexts.unshift(entry)
+      if (T.statusTexts.length > STATUSTEXT_BUFFER) T.statusTexts.length = STATUSTEXT_BUFFER
       break
     }
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,5 +2,6 @@
   <div class="min-h-screen">
     <ReadinessStrip />
     <slot />
+    <StatusTextFeed />
   </div>
 </template>

--- a/pages/gcs.vue
+++ b/pages/gcs.vue
@@ -9,6 +9,7 @@
     <div class="flex-1 min-h-0">
       <GCSLayout :flight-controls-ref="flightControlsRef" />
     </div>
+    <StatusTextFeed class="shrink-0 m-2" />
   </div>
 </template>
 

--- a/pages/gcs.vue
+++ b/pages/gcs.vue
@@ -9,7 +9,6 @@
     <div class="flex-1 min-h-0">
       <GCSLayout :flight-controls-ref="flightControlsRef" />
     </div>
-    <StatusTextFeed class="shrink-0 m-2" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
QGC-style PX4 message handling layered over the rest of the GCS chrome.

- `useTelemetry` now parses **STATUSTEXT** frames from mavlink2rest into a 50-entry ring buffer (newest first), with severity mapping for both numeric and \`MAV_SEVERITY_*\` string envelopes, and a 500ms dedupe window for PX4's multi-fragment STATUSTEXT (long messages split into fragments).
- `<StatusTextFeed />` mounted in the default layout, three surfaces:
  - **Toast** at top-center that flashes when a new message arrives, severity-colored, auto-fades after 5s.
  - **Floating log panel** at bottom-right (scrollable, severity-colored rows, close button), opened on demand.
- **`MSG` pill in the ReadinessStrip** (left of MODE) — color tracks the severity of the latest message, value shows \"N new\" with red unseen badge or total count when all seen. Click toggles the log panel.
- New \`useStatusLog\` composable owns \`logOpen\` + \`lastSeenCount\` as a module-level singleton so the pill (strip) and the panel (feed) stay in sync.

**Strip polish along the way**
- Pill padding 0.2/0.55 → 0.35/0.75 rem; strip padding 0.4/1 → 0.6/1.5 rem so the row breathes.
- Dropped the standalone \"FC live\" pill — the Mode pill now carries link state (\`FC OFFLINE\` / \`FC LOST Ns\`) when mavlink2rest hasn't seen a HEARTBEAT.

Closes #38.

> **Stacked on #41** — merge that one first.

## Commits
- \`feat(gcs): STATUSTEXT message feed panel (closes #38)\`
- \`polish: breathe pill row, drop FC pill, QGC-style STATUSTEXT overlay\`
- \`feat(strip): MSG pill in ReadinessStrip, drop floating chip\`

## Test plan
- [ ] On startup with active FC, MSG pill shows \"0\" (gray)
- [ ] Arm the drone → STATUSTEXT \"ARMED\" arrives → toast appears top-center, MSG pill turns at correct severity color, shows \"1 new\"
- [ ] Click MSG pill → log panel opens at bottom-right with the message and timestamp
- [ ] Click pill again → panel closes; pill now shows total count (no \"new\")
- [ ] Critical messages render in red (severity ≤ ERROR), warnings amber, info gray
- [ ] Multi-fragment STATUSTEXTs collapse into a single entry (no duplicates within 500ms)