### PR TITLE
Replay PR #44: GCS chrome polish + critical fixes (HEARTBEAT armed, ALT jitter, layout)

### DIFF
--- a/components/CameraFeed.vue
+++ b/components/CameraFeed.vue
@@ -1,15 +1,31 @@
 <template>
   <div class="camera-container">
-    <img 
-      v-if="imageData" 
-      :src="imageData" 
-      alt="ROS Image" 
+    <img
+      v-if="imageData"
+      :src="imageData"
+      alt="ROS Image"
       class="camera-feed"
-      :style="{ transform: shouldInvert ? 'rotate(180deg)' : 'none' }"
+      :style="{ transform: inverted ? 'rotate(180deg)' : 'none' }"
     />
     <div v-else class="flex items-center justify-center h-full">
       <p class="text-gray-400 text-xl font-semibold">Loading image...</p>
     </div>
+
+    <!-- Rotate overlay button (top-right of the image). Toggles 180° flip
+         for upside-down or mirrored mounts. Always rendered so the
+         affordance is visible even before a stream arrives. -->
+    <button
+      class="rotate-btn"
+      :class="{ 'is-active': inverted }"
+      @click="inverted = !inverted"
+      :title="inverted ? 'Restore orientation' : 'Rotate 180°'"
+      aria-label="Rotate camera 180 degrees"
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12a9 9 0 1 1-3-6.7" />
+        <path d="M21 3v6h-6" />
+      </svg>
+    </button>
   </div>
 </template>
 
@@ -20,6 +36,8 @@ import { useROS } from '~/composables/useROS'
 export default {
   name: 'CameraFeed',
   props: {
+    // Initial orientation. Kept for backward compatibility — the rotate-btn
+    // overlay below is the source of truth for runtime toggling.
     shouldInvert: {
       type: Boolean,
       default: false
@@ -32,8 +50,12 @@ export default {
   data() {
     return {
       imageData: null,
-      imageTopic: null
+      imageTopic: null,
+      inverted: this.shouldInvert,
     };
+  },
+  watch: {
+    shouldInvert(v) { this.inverted = v; },
   },
   mounted() {
     const { getROSURL } = useROS()
@@ -52,7 +74,7 @@ export default {
       queue_length: 1,
     });
 
-    this.imageTopic.subscribe((message) => {      
+    this.imageTopic.subscribe((message) => {
       this.imageData = `data:image/jpeg;base64,${message.data}`;
     });
   },
@@ -66,6 +88,7 @@ export default {
 
 <style scoped>
 .camera-container {
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
@@ -79,4 +102,29 @@ export default {
   height: 100%;
   object-fit: contain;
 }
-</style> 
+
+.rotate-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: rgb(226 232 240);
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  transition: filter 0.12s ease, background-color 0.12s ease;
+}
+.rotate-btn:hover { filter: brightness(1.3); }
+.rotate-btn.is-active {
+  background: rgba(96, 165, 250, 0.45);
+  border-color: rgba(96, 165, 250, 0.7);
+  color: white;
+}
+.rotate-btn svg { width: 18px; height: 18px; }
+</style>

--- a/components/GCSLayout.vue
+++ b/components/GCSLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col h-full">
-    <MainMenu ref="mainMenuRef" @open-keyboard-control="showKeyboardControl = true" />
+    <MainMenu @open-keyboard-control="showKeyboardControl = true" />
     <!-- Main Content -->
     <div class="flex-1 flex flex-col md:flex-row overflow-hidden">
       <!-- Main Content Area with Tabs -->
@@ -40,7 +40,7 @@
         <div class="flex-1 relative min-h-0">
           <!-- Camera Tab -->
           <div v-if="activeTab === 'camera'" class="p-2 sm:p-4 h-full">
-            <CameraFeed :should-invert="mainMenuRef?.cameraInverted ?? false" />
+            <CameraFeed />
           </div>
 
           <!-- Map Tab -->
@@ -112,7 +112,6 @@ const route = useRoute();
 // Tab management
 const activeTab = ref('camera');
 const droneGridRef = ref();
-const mainMenuRef = ref();
 
 // Keyboard control modal
 const showKeyboardControl = ref(false);

--- a/components/MainMenu.vue
+++ b/components/MainMenu.vue
@@ -1,35 +1,35 @@
 <template>
   <div class="relative">
     <!-- Hamburger Icon -->
-    <button 
+    <button
       @click="isOpen = !isOpen"
       class="fixed top-4 right-4 z-50 p-2 rounded-lg bg-gray-800 text-white hover:bg-gray-700 focus:outline-none"
     >
-      <svg 
-        class="w-6 h-6" 
-        fill="none" 
-        stroke="currentColor" 
+      <svg
+        class="w-6 h-6"
+        fill="none"
+        stroke="currentColor"
         viewBox="0 0 24 24"
       >
-        <path 
+        <path
           v-if="!isOpen"
-          stroke-linecap="round" 
-          stroke-linejoin="round" 
-          stroke-width="2" 
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
           d="M4 6h16M4 12h16M4 18h16"
         />
-        <path 
+        <path
           v-else
-          stroke-linecap="round" 
-          stroke-linejoin="round" 
-          stroke-width="2" 
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
           d="M6 18L18 6M6 6l12 12"
         />
       </svg>
     </button>
 
     <!-- Slide-out Menu -->
-    <div 
+    <div
       class="fixed top-0 right-0 h-full w-64 bg-gray-800 text-white transform transition-transform duration-300 ease-in-out z-40"
       :class="isOpen ? 'translate-x-0' : 'translate-x-full'"
     >
@@ -43,12 +43,6 @@
             Dashboard
           </NuxtLink>
           <button
-            class="w-full text-left py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
-            @click="toggleCameraRotation"
-          >
-            Rotate Camera
-          </button>
-          <button
             v-if="keyboardControlAvailable"
             class="w-full text-left py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors"
             @click="openKeyboardControl"
@@ -60,7 +54,7 @@
     </div>
 
     <!-- Backdrop -->
-    <div 
+    <div
       v-if="isOpen"
       class="fixed inset-0 bg-black bg-opacity-50 z-30"
       @click="isOpen = false"
@@ -74,14 +68,8 @@ import { ref } from 'vue'
 import { useDexiPlatform } from '~/composables/useDexiPlatform'
 
 const isOpen = ref(false)
-const cameraInverted = ref(false) // Camera displays right-side up by default
 
 const { keyboardControlEnabled: keyboardControlAvailable } = useDexiPlatform()
-
-const toggleCameraRotation = () => {
-  cameraInverted.value = !cameraInverted.value
-  isOpen.value = false
-}
 
 const emit = defineEmits(['open-keyboard-control'])
 
@@ -89,8 +77,4 @@ const openKeyboardControl = () => {
   emit('open-keyboard-control')
   isOpen.value = false
 }
-
-defineExpose({
-  cameraInverted
-})
-</script> 
+</script>

--- a/components/Pill.vue
+++ b/components/Pill.vue
@@ -4,12 +4,18 @@
 // `state` controls color: green / amber / red / gray.
 // When `clickable`, renders as a button with hover styles and emits `click`.
 
-defineProps<{
+const props = defineProps<{
   label?: string
   value: string
   state: 'green' | 'amber' | 'red' | 'gray'
   clickable?: boolean
   active?: boolean
+  /**
+   * Reserve a fixed character width for the value with tabular-nums + right
+   * alignment, so the pill doesn't jitter horizontally as the value's char
+   * count changes (e.g., `9.5m` → `10.2m`). Pass a CSS length like "6ch".
+   */
+  valueWidth?: string
 }>()
 
 defineEmits<{ click: [event: MouseEvent] }>()
@@ -25,7 +31,11 @@ defineEmits<{ click: [event: MouseEvent] }>()
   >
     <span class="dot" />
     <span v-if="label" class="pill-label">{{ label }}</span>
-    <span class="pill-value">{{ value }}</span>
+    <span
+      class="pill-value"
+      :class="{ 'pill-value-numeric': valueWidth }"
+      :style="valueWidth ? { minWidth: valueWidth } : undefined"
+    >{{ value }}</span>
     <svg
       v-if="clickable"
       class="caret"
@@ -65,6 +75,11 @@ defineEmits<{ click: [event: MouseEvent] }>()
 .pill-value {
   color: rgb(241 245 249);
   font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.pill-value-numeric {
+  display: inline-block;
+  text-align: right;
 }
 .caret {
   width: 9px;

--- a/components/ReadinessStrip.vue
+++ b/components/ReadinessStrip.vue
@@ -9,14 +9,15 @@ import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useTelemetry } from '~/composables/useTelemetry'
 import { useMavlinkCommand } from '~/composables/useMavlinkCommand'
 import { useStatusLog } from '~/composables/useStatusLog'
-import { useRoute } from 'vue-router'
+import { useStripVisibility } from '~/composables/useStripVisibility'
 
-const route = useRoute()
 const { telemetry, perCellVoltage, ageMs } = useTelemetry()
 const { arm, disarm, setMode } = useMavlinkCommand()
 const { totalCount: msgTotal, unseenCount: msgUnseen, latest: msgLatest, toggleLog } = useStatusLog()
 
-const visible = computed(() => route.path !== '/' && route.path !== '/index')
+// Visibility owned by composables/useStripVisibility.ts so this component
+// and layouts/default.vue agree on which routes get the strip.
+const { visible } = useStripVisibility()
 const fmt = (n: number | null, d = 1) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(d))
 const connectionAge = computed(() => (ageMs.value / 1000).toFixed(0))
 
@@ -241,12 +242,12 @@ onBeforeUnmount(() => {
         @click="onArmPillClick"
       />
 
-      <Pill label="Battery" :state="battery.state" :value="battery.label" />
+      <Pill label="Battery" :state="battery.state" :value="battery.label" value-width="13ch" />
       <Pill label="EKF" :state="ekf.state" :value="ekf.label" />
-      <Pill label="Range" :state="range.state" :value="range.label" />
-      <Pill label="Alt" :state="altitude.state" :value="altitude.label" />
-      <Pill label="Spd" :state="speed.state" :value="speed.label" />
-      <Pill label="Hdg" :state="heading.state" :value="heading.label" />
+      <Pill label="Range" :state="range.state" :value="range.label" value-width="5ch" />
+      <Pill label="Alt" :state="altitude.state" :value="altitude.label" value-width="6ch" />
+      <Pill label="Spd" :state="speed.state" :value="speed.label" value-width="7ch" />
+      <Pill label="Hdg" :state="heading.state" :value="heading.label" value-width="4ch" />
     </div>
   </div>
 </template>
@@ -257,8 +258,15 @@ onBeforeUnmount(() => {
   border-bottom: 1px solid rgb(30 41 59);
   color: rgb(241 245 249);
   padding: 0.6rem 1.5rem;
-  position: sticky;
+  /* Fixed overlay at viewport top. Hard-coded height: 48px in
+   * layouts/default.vue assumes this stays close to that — if you change
+   * padding/font-size and the strip's natural height drifts, update both. */
+  position: fixed;
   top: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  box-sizing: border-box;
   z-index: 30;
   font-size: 0.8rem;
 }

--- a/composables/useStripVisibility.ts
+++ b/composables/useStripVisibility.ts
@@ -1,0 +1,14 @@
+// useStripVisibility — single source of truth for which routes get the
+// ReadinessStrip. Used by both the strip itself (whether to render) and the
+// default layout (whether to carve 48px out of layout-page's top).
+
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const HIDE_ON = new Set(['/', '/index', '/status'])
+
+export function useStripVisibility() {
+  const route = useRoute()
+  const visible = computed(() => !HIDE_ON.has(route.path))
+  return { visible }
+}

--- a/composables/useTelemetry.ts
+++ b/composables/useTelemetry.ts
@@ -27,7 +27,7 @@ export interface Telemetry {
   }
   altitude: {
     msl: number | null          // m (from ALTITUDE)
-    relative: number | null     // m above home (from VFR_HUD/ALTITUDE)
+    relative: number | null     // m above home (from ALTITUDE.altitude_relative only — VFR_HUD.alt is MSL, not relative)
     terrain: number | null      // m above ground (from ALTITUDE.altitude_terrain)
   }
   speed: {
@@ -154,9 +154,20 @@ function handleMavlinkMessage(envelope: any) {
     case 'HEARTBEAT': {
       T.lastHeartbeatMs = Date.now()
       T.connected = true
-      const base = Number(m.base_mode ?? 0)
-      T.mode.base = base
-      T.armed = (base & 0x80) !== 0  // MAV_MODE_FLAG_SAFETY_ARMED
+      // base_mode comes through as either a raw bitmask int (e.g., 81) OR a
+      // pipe-joined enum string ("MAV_MODE_FLAG_SAFETY_ARMED | MAV_MODE_FLAG_..."),
+      // depending on the mavlink2rest serialization. Handle both: parse the
+      // string for SAFETY_ARMED, fall back to the bitmask if numeric.
+      let armed = false
+      let baseInt: number | null = null
+      if (typeof m.base_mode === 'string') {
+        armed = m.base_mode.includes('SAFETY_ARMED')
+      } else if (typeof m.base_mode === 'number') {
+        baseInt = m.base_mode
+        armed = (m.base_mode & 0x80) !== 0  // MAV_MODE_FLAG_SAFETY_ARMED
+      }
+      T.mode.base = baseInt
+      T.armed = armed
       T.mode.custom = Number(m.custom_mode ?? 0)
       T.mode.name = decodePx4ModeName(T.mode.custom)
       break
@@ -184,7 +195,10 @@ function handleMavlinkMessage(envelope: any) {
       break
     }
     case 'VFR_HUD': {
-      T.altitude.relative = Number.isFinite(m.alt) ? m.alt : T.altitude.relative
+      // VFR_HUD.alt is MSL per MAVLink spec — write to msl, NOT relative.
+      // (Previously this clobbered T.altitude.relative with AMSL values and
+      // fought ALTITUDE.altitude_relative at ~25 Hz, jittering the pill.)
+      T.altitude.msl = Number.isFinite(m.alt) ? m.alt : T.altitude.msl
       T.speed.ground = Number.isFinite(m.groundspeed) ? m.groundspeed : T.speed.ground
       T.speed.vertical = Number.isFinite(m.climb) ? m.climb : T.speed.vertical
       T.heading = Number.isFinite(m.heading) ? m.heading : T.heading

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,40 @@
 <template>
-  <div class="min-h-screen">
+  <div class="layout-root" :class="{ 'has-strip': stripVisible }">
     <ReadinessStrip />
-    <slot />
+    <main class="layout-page"><slot /></main>
     <StatusTextFeed />
   </div>
 </template>
+
+<script setup lang="ts">
+import { useStripVisibility } from '~/composables/useStripVisibility'
+
+const { visible: stripVisible } = useStripVisibility()
+</script>
+
+<style scoped>
+/* ReadinessStrip is fixed at viewport top. layout-page is absolutely
+ * positioned and fills the area below it. When the strip is hidden, the
+ * layout-page reclaims the full viewport.
+ *
+ * Why absolute positioning instead of flex: pages that use `height: 100%`
+ * (Blockly, Unity sim) need a parent with a definite height. flex-derived
+ * heights are technically definite but trigger circular-dependency edge
+ * cases when the child also uses percent height. Absolute top/bottom is
+ * the bulletproof path. */
+.layout-root {
+  position: relative;
+  min-height: 100vh;
+}
+.layout-page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+.has-strip .layout-page {
+  top: 48px;
+}
+</style>

--- a/pages/droneblocks.vue
+++ b/pages/droneblocks.vue
@@ -2294,8 +2294,11 @@ onUnmounted(() => {
 .droneblocks-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  width: 100vw;
+  /* Sized by the layout's flex column so the persistent ReadinessStrip stays
+   * visible. Previously this used `height: 100vh` which fought the strip's
+   * 50px and let the page settle into a state where the strip scrolled off. */
+  height: 100%;
+  width: 100%;
   margin: 0;
   padding: 0;
   overflow: hidden;

--- a/pages/gcs.vue
+++ b/pages/gcs.vue
@@ -4,7 +4,7 @@
       <DroneGrid />
     </FlightControls>
   </div> -->
-  <div class="flex flex-col h-screen overflow-hidden">
+  <div class="flex flex-col h-full overflow-hidden">
     <FlightControls ref="flightControlsRef" class="shrink-0" />
     <div class="flex-1 min-h-0">
       <GCSLayout :flight-controls-ref="flightControlsRef" />

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-screen">
+  <div class="flex flex-col h-full">
     <MainMenu />
     <!-- Flight Controls -->
     <FlightControls ref="flightControlsRef" />


### PR DESCRIPTION
## Why this exists

PR #44 squash-merged into its base branch \`pr/statustext-overlay\` at 20:38 UTC on 2026-06-08, after PR #42 had already squash-merged \`pr/statustext-overlay\` into main at 19:54 UTC. The path from #44's base to main was severed at that point — the squash commit (\`21bebf7\`) is orphaned: it exists on GitHub but is unreachable from \`main\`.

This PR cherry-picks that orphaned squash onto main so the content actually lands.

## Content

Same diff as the original #44 — 11 files, 183 insertions / 65 deletions. Includes:

1. **fix(useTelemetry)**: HEARTBEAT \`base_mode\` string parse, VFR_HUD altitude semantic — without these the armed flag never turns true and the ALT pill flickers between MSL and relative
2. **feat(Pill)**: valueWidth + tabular-nums — no more horizontal jitter as values update
3. **feat(layout)**: absolute-positioned page slot + position:fixed strip + \`useStripVisibility\` composable — pages with 100vh roots stop fighting the strip; \`/status\` reclaims the top 48px
4. **feat(CameraFeed)**: rotate overlay button + drop Rotate Camera from MainMenu

See the original #44 description for the per-commit rationale.

## Test plan

- [ ] On \`/gcs\`, arm via the readiness-strip Arm pill — pill flips red after PX4 ACKs
- [ ] ALT pill reads steady relative altitude, no flicker to MSL
- [ ] Pill row doesn't jitter horizontally as values change
- [ ] On \`/droneblocks\`, page header (Tag, NED, Tutorials, Launch) stays visible and doesn't slide under the strip
- [ ] On \`/status\`, strip is hidden
- [ ] Camera tab rotate icon flips the feed 180° and tints blue when active
- [ ] Hamburger menu shows only Dashboard + Keyboard Control