### PR TITLE
feat(status): Top Processes panel — install procps + friendly ROS node names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ FROM node:20-slim AS runner
 
 WORKDIR /app
 
-# Install iw for wifi SSID detection, nmcli for network management
-RUN apt-get update && apt-get install -y --no-install-recommends iw network-manager && rm -rf /var/lib/apt/lists/*
+# Install runtime utilities:
+#   - iw + network-manager: WiFi SSID detection + connection management
+#   - procps: provides `top` for /api/system-status Top Processes panel
+RUN apt-get update && apt-get install -y --no-install-recommends iw network-manager procps && rm -rf /var/lib/apt/lists/*
 
 # Copy built output
 COPY --from=builder /app/.output ./.output

--- a/server/api/system-status.get.ts
+++ b/server/api/system-status.get.ts
@@ -201,11 +201,30 @@ async function getCpuStats(): Promise<CpuStats> {
   }
 }
 
-// Top N processes by CPU% — uses `top -bn2 -d 0.5`, second iteration gives a
-// real sample window (first iteration's %CPU is cumulative-since-start, useless).
+// Resolve a friendly display name from a full command line. Bare `comm` is
+// misleading for ROS nodes — every Python-based node shows as `python3` and
+// every image throttler shows as `throttle`. The full command line carries
+// the real identity in either `__node:=<name>` (set by `ros2 launch`) or
+// the script path. Resolution order:
+//   1. ROS launch arg: `... --ros-args -r __node:=foo` → "foo"
+//   2. First .py token in the command → basename without `.py`
+//   3. Fallback: basename of the first token (original behavior)
+function friendlyName(cmd: string): string {
+  if (!cmd) return cmd;
+  const rosMatch = cmd.match(/__node:=(\S+)/);
+  if (rosMatch) return rosMatch[1];
+  const pyToken = cmd.split(/\s+/).find((t) => t.endsWith(".py"));
+  if (pyToken) return pyToken.split("/").pop()!.replace(/\.py$/, "");
+  return cmd.split(/\s+/)[0].split("/").pop() || cmd;
+}
+
+// Top N processes by CPU% — uses `top -bn2 -d 0.5 -c`, second iteration gives
+// a real sample window (first iteration's %CPU is cumulative-since-start,
+// useless). `-c` shows full command line so friendlyName() has data to work
+// with. `-w512` keeps the COMMAND column from being truncated.
 interface TopProcess { pid: number; cpuPct: number; command: string }
 async function getTopProcesses(limit = 5): Promise<TopProcess[] | null> {
-  const raw = await run("top -bn2 -d 0.5 -w512 -o %CPU 2>/dev/null");
+  const raw = await run("top -bn2 -d 0.5 -w512 -o %CPU -c 2>/dev/null");
   if (!raw) return null;
   // Find the SECOND "PID  USER ..." header — its block is the real sample.
   const lines = raw.split("\n");
@@ -228,7 +247,7 @@ async function getTopProcesses(limit = 5): Promise<TopProcess[] | null> {
     const cpuPct = Number(parts[8]); // %CPU column in `top` BATCH output
     if (!Number.isFinite(pid) || !Number.isFinite(cpuPct)) continue;
     if (cpuPct < 0.1) continue;
-    out.push({ pid, cpuPct, command: parts.slice(11).join(" ") });
+    out.push({ pid, cpuPct, command: friendlyName(parts.slice(11).join(" ")) });
   }
   return out.sort((a, b) => b.cpuPct - a.cpuPct).slice(0, limit);
 }


### PR DESCRIPTION
## Why

The `/status` Top Processes panel never works in production on real DEXI hardware today. Two reasons, both fixed in this PR:

1. **`top` is missing.** The `node:20-slim` base image has no `procps`, so the API returns `null` and the panel doesn't render.

2. **Even with `top` present, the labels are useless.** The current code reads the `comm` column — but every Python ROS node shows as `python3` and every image throttler as `throttle`. You can't tell `rosbridge_websocket` from `color_detection_node` from a YOLO inference loop. Triaging "what's burning my CPU?" requires SSH'ing to the Pi and grepping `/proc/<pid>/cmdline`.

## What changed

- **`Dockerfile`**: add `procps` to the runtime apt install list.
- **`server/api/system-status.get.ts`**:
  - Pass `-c` to `top` so the COMMAND column is the full command line.
  - New `friendlyName()` resolver that prefers `__node:=<name>` (the ROS launch-args node name) over the script basename over the binary basename.

## Result on a real CM5

Verified live on a DEXI CM5 with the standard `dexi_bringup` running:

| Before | After |
|---|---|
| `python3` (770) | `rosbridge_websocket` (770) |
| `python3` (794) | `color_detection_node` (794) |
| `throttle` (786) | `image_throttle_raw_node` (786) |
| `camera_node` (780) | `cam0` (780) |
| `micro_ros_agent` (768) | `micro_ros_agent` (768) |

The two indistinguishable `python3` entries become the actual ROS node names. `cam0` instead of `camera_node` because `camera_node` is the binary; `cam0` is the ROS node name visible in `ros2 node list` — which is what you'd run to dig deeper.

## Companion change needed in `dexi-os`

This PR alone gets us `top` inside the container, but the container's PID namespace still hides host processes. A one-line change in `dexi-os/resources/first_boot.sh` (separate PR) adds `--pid=host` to the dexi-droneblocks `docker run` invocation. Without it, the panel only shows the container's ~4 PIDs (the Nuxt server). With both PRs landed, the full host process list is visible.

Graceful degradation: if `--pid=host` isn't set, the panel just shows the Nuxt server's own processes — no crash, no error.

## Test plan

- [ ] Re-trigger `release.yml` with tag `0.20` after merge to publish the rebuilt image
- [ ] On a CM5 with `--pid=host` already added: pull, recreate container, verify Top Processes shows friendly names for `rosbridge_websocket`, the offboard manager, camera node, AprilTag node, etc.
- [ ] Verify CPU% values still make sense (they should — only the `command` column changed)