### PR TITLE
Add aurora LED effect to led_effect dropdown

### DIFF
--- a/assets/ts/led.ts
+++ b/assets/ts/led.ts
@@ -12,6 +12,7 @@ export class LED {
             "type": "field_dropdown",
             "name": "effect",
             "options": [
+              ["aurora", "aurora"],
               ["comet", "comet"],
               ["festive", "festive"],
               ["galaxy", "galaxy"],


### PR DESCRIPTION
Adds the new `aurora` effect to the `led_effect` Blockly block dropdown so it's selectable in DroneBlocks.

The backend already supports it:
- `dexi_led` service (cm4/pi5) — aurora handler merged (PR #4)
- `dexi_led` Unity bridge — aurora merged (PR #5)
- `node-red-dexi` — aurora dropdown published (v0.0.18, PR #11)

This was the last missing piece. `pythonGenerator.ts` reads the dropdown value dynamically (`mission.set_led_effect('${effect}')`), so no generator change is needed — the value flows straight through.

After merge: rebuild the `dexi-droneblocks` docker image and push `dexi-droneblocks.tar` to R2 (`r2:dexi-os-releases/build-assets/`) before the next dexi-os build.