### PR TITLE
Stream GCS camera at higher fps with CBOR transport

### DIFF
--- a/components/CameraFeed.vue
+++ b/components/CameraFeed.vue
@@ -70,17 +70,32 @@ export default {
       ros: ros,
       name: this.topicName,
       messageType: 'sensor_msgs/CompressedImage',
-      throttle_rate: 200,
+      throttle_rate: 33,   // ~30 fps target (was 200 = 5 fps); camera currently
+                           // caps ~21 fps. rosbridge serializes once and shares
+                           // across viewers, so the higher rate costs ~1% CPU total.
       queue_length: 1,
+      // CBOR sends the JPEG as binary instead of base64-in-JSON (~26% less
+      // bandwidth, no base64 decode in the browser). roslib decodes the frame
+      // so message.data arrives as a byte array, not a base64 string.
+      compression: 'cbor',
     });
 
     this.imageTopic.subscribe((message) => {
-      this.imageData = `data:image/jpeg;base64,${message.data}`;
+      const blob = new Blob([new Uint8Array(message.data)], { type: 'image/jpeg' });
+      const url = URL.createObjectURL(blob);
+      // Release the previous frame's blob URL to avoid leaking one per frame.
+      if (this.imageData && this.imageData.startsWith('blob:')) {
+        URL.revokeObjectURL(this.imageData);
+      }
+      this.imageData = url;
     });
   },
   beforeDestroy() {
     if (this.imageTopic) {
       this.imageTopic.unsubscribe();
+    }
+    if (this.imageData && this.imageData.startsWith('blob:')) {
+      URL.revokeObjectURL(this.imageData);
     }
   }
 };


### PR DESCRIPTION
## What
Makes the camera feed smoother and lighter on the wire, in one shared component (`CameraFeed.vue`) that backs every camera pane (GCS, droneblocks, apriltag, camera).

- **Frame rate:** `throttle_rate` 200ms → **33ms** (5 fps → ~30 fps target). The camera source currently caps around ~21 fps, so delivered rate is camera-limited, not throttle-limited.
- **Transport:** switch the image subscription to rosbridge **CBOR** compression instead of base64-in-JSON.
- **Render:** decode the binary frame to a `Blob` URL and `revokeObjectURL` the previous frame each tick (and on destroy) to avoid leaking one object URL per frame.

## Why / measured on hardware (CM5, dexi-9e6a)
- **Bandwidth:** base64 28.8 KB/frame → CBOR 21.4 KB/frame = **−26%**, plus no base64 decode in the browser.
- **CPU is cheap and shared:** rosbridge serializes a frame **once** and reuses the buffer for all subscribers on the same topic+options. Measured rosbridge CPU by frame rate (single stream): 5 fps 4.9% → 15 fps 5.6% → ~30 fps 6.3%. Multi-client stays ~flat (1/2/4 clients ≈ 7.2/7.5/8.2% @30fps). So raising fps costs ~1% total, not per-viewer.
- Live load with this rate streaming: 4-core load ~0.96, 44 °C, 21% mem — ample headroom.

## Notes
- `cbor-raw` is broken on the deployed rosbridge 2.6.0 (returns no frames); plain `cbor` works and is used here.
- Bump `33` → `50` for 20 fps or back to `66` for 15 fps if a lower rate is preferred; behavior is identical otherwise.
- Takes effect on the next dexi-droneblocks image build/deploy.